### PR TITLE
REPAIRING what was broken in https://github.com/ecboghiu/inflation/co…

### DIFF
--- a/causalinflation/quantum/general_tools.py
+++ b/causalinflation/quantum/general_tools.py
@@ -166,26 +166,6 @@ def flatten_symbolic_powers(monomial: sympy.core.symbol.Symbol
     return factors
 
 
-def to_symbol(monomial: np.ndarray, names: Tuple[str]) -> sympy.core.symbol.Symbol:
-    """Converts a monomial to a symbolic representation.
-    """
-    if np.array_equal(monomial, np.array([[0]], dtype=np.uint16)):
-        return sympy.S.One
-
-    if type(monomial) == str:
-        monomial = to_numbers(monomial, names)
-    monomial = monomial.tolist()
-    symbols = []
-    for letter in monomial:
-        symbols.append(sympy.Symbol("_".join([names[letter[0] - 1]] +
-                                             [str(i) for i in letter[1:]]),
-                                    commutative=False))
-    prod = sympy.S.One
-    for s in symbols:
-        prod *= s
-    return prod
-
-
 def to_numbers(monomial: str,
                parties_names: Tuple[str]
                ) -> np.ndarray:


### PR DESCRIPTION
…mmit/28e08df01942b1ade549c6ec9b04a8d72dcba9b1

1) build_columns now ALWAYS returns ONLY the numpy array representation. So, we need to remove the unused return_columns_numerical keyword, and fix a bunch of tests. 2) to_symbol is now deprecated. I removed the import from InflationSDP and the function from general_tools.py 3) the has_children attribute of InflationSDP must be modified when support_problem=True, so I have reverted the change made in the problematic commit.