### PR TITLE
Improve handling of bounds

### DIFF
--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -982,7 +982,7 @@ class InflationSDP(object):
         """
         if type(which) == str:
             if which == "all":
-                self.reset(["bounds", "objective", "values"])
+                self.reset(["values", "bounds", "objective"])
             elif which == "bounds":
                 self._reset_lowerbounds()
                 self._reset_upperbounds()

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -376,8 +376,6 @@ class InflationSDP(object):
         self.moment_upperbounds  = dict()
         self.moment_lowerbounds  = {m: 0. for m in self.physical_monomials}
 
-        self._set_lowerbounds(None)
-        self._set_upperbounds(None)
         self.set_objective(None)
         self.set_values(None)
 

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -1702,6 +1702,8 @@ class InflationSDP(object):
     def _reset_lowerbounds(self) -> None:
         """Reset the list of lower bounds."""
         self._reset_solution()
+        self.moment_lowerbounds = {m: 0. for m in self.physical_monomials}
+        self._update_lowerbounds()
 
     def _reset_upperbounds(self) -> None:
         """Reset the list of upper bounds."""

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -155,6 +155,7 @@ class TestReset(unittest.TestCase):
     sdp = InflationSDP(trivial)
     sdp.generate_relaxation("npa1")
     physical_bounds = {m: 0. for m in sdp.physical_monomials}
+    del physical_bounds[sdp.One]
 
     def prepare_objects(self, infSDP):
         var1 = infSDP.measurements[0][0][0][0]
@@ -183,9 +184,11 @@ class TestReset(unittest.TestCase):
 
     def test_reset_bounds(self):
         self.prepare_objects(self.sdp)
+        correct = {key: val for key, val in self.physical_bounds.items()
+                   if key not in self.sdp.known_moments}
         self.sdp.reset("bounds")
         self.assertEqual(self.sdp.moment_lowerbounds,
-                         self.physical_bounds,
+                         correct,
                          "Resetting lower bounds fails.")
         self.assertEqual(self.sdp.moment_upperbounds, dict(),
                          "Resetting upper bounds fails.")

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -170,12 +170,7 @@ class TestReset(unittest.TestCase):
         self.assertEqual(self.sdp.moment_lowerbounds,
                          self.physical_bounds,
                          "Resetting lower bounds fails.")
-        self.assertEqual(self.sdp._processed_moment_lowerbounds,
-                         self.physical_bounds,
-                         "Resetting processed lower bounds fails.")
         self.assertEqual(self.sdp.moment_upperbounds, dict(),
-                         "Resetting processed upper bounds fails.")
-        self.assertEqual(self.sdp._processed_moment_upperbounds, dict(),
                          "Resetting processed upper bounds fails.")
         self.assertEqual(self.sdp.objective, {self.sdp.One: 0.},
                          "Resetting the objective function fails.")
@@ -192,13 +187,8 @@ class TestReset(unittest.TestCase):
         self.assertEqual(self.sdp.moment_lowerbounds,
                          self.physical_bounds,
                          "Resetting lower bounds fails.")
-        self.assertEqual(self.sdp._processed_moment_lowerbounds,
-                         self.physical_bounds,
-                         "Resetting processed lower bounds fails.")
         self.assertEqual(self.sdp.moment_upperbounds, dict(),
                          "Resetting upper bounds fails.")
-        self.assertEqual(self.sdp._processed_moment_upperbounds, dict(),
-                         "Resetting processed upper bounds fails.")
         self.assertTrue(len(self.sdp.objective) == 2,
                         "Resetting the bounds resets the objective function.")
         self.assertTrue(len(self.sdp.known_moments) == 3,
@@ -217,14 +207,8 @@ class TestReset(unittest.TestCase):
                          "known_moments.")
         self.assertTrue(len(self.sdp.moment_lowerbounds) == 4,
                         "Lower bounds are being reset when they should not.")
-        self.assertTrue(len(self.sdp._processed_moment_lowerbounds) == 4,
-                        "Processed lowerbounds are being reset when they " +
-                        "should not.")
         self.assertTrue(len(self.sdp.moment_upperbounds) == 1,
                         "Upper bounds are being reset when they should not.")
-        self.assertTrue(len(self.sdp._processed_moment_upperbounds) == 1,
-                        "Processed upperbounds are being reset when they " +
-                        "should not.")
 
     def test_reset_objective(self):
         self.prepare_objects(self.sdp)
@@ -235,14 +219,8 @@ class TestReset(unittest.TestCase):
                         "Resetting the objective resets the known moments.")
         self.assertTrue(len(self.sdp.moment_lowerbounds) == 4,
                         "Resetting the objective resets the lower bounds.")
-        self.assertTrue(len(self.sdp._processed_moment_lowerbounds) == 4,
-                        "Resetting the objective resets the processed " +
-                        "lower bounds.")
         self.assertTrue(len(self.sdp.moment_upperbounds) == 1,
                         "Resetting the objective resets the upper bounds.")
-        self.assertTrue(len(self.sdp._processed_moment_upperbounds) == 1,
-                        "Resetting the objective resets the processed " +
-                        "upper bounds.")
 
     def test_reset_values(self):
         self.prepare_objects(self.sdp)
@@ -255,14 +233,8 @@ class TestReset(unittest.TestCase):
                          "known_moments.")
         self.assertTrue(len(self.sdp.moment_lowerbounds) == 4,
                         "Resetting the objective resets the lower bounds.")
-        self.assertTrue(len(self.sdp._processed_moment_lowerbounds) == 4,
-                        "Resetting the objective resets the processed " +
-                        "lower bounds.")
         self.assertTrue(len(self.sdp.moment_upperbounds) == 1,
                         "Resetting the objective resets the upper bounds.")
-        self.assertTrue(len(self.sdp._processed_moment_upperbounds) == 1,
-                        "Resetting the objective resets the processed " +
-                        "upper bounds.")
         self.assertTrue(len(self.sdp.objective) == 2,
                         "Resetting the bounds resets the objective function.")
 


### PR DESCRIPTION
I noticed a potentially not desired feature, namely that `_reset_lowerbounds()` eliminated all the lower bounds instead of reinstating the non-negativity constraints for physical monomials, and that motivated me to do a small revamp the handling of bounds. The main features of the PR are:

- `_processed_moment_upperbounds` and `_processed_moment_lowerbounds` are removed. I noticed that in the code we were effectively working exclusively with these two objects and not using `moment_upperbounds` and `moment_lowerbounds` at all (except for a tiny case that is properly addressed). Therefore, I renassigned `_processed_moment_(upp/low)erbounds` to `moment_(upp/low)erbounds`.
- Setting lowerbounds, in contrast to previously, now keeps the non-negativity bounds, which is a natural choice (we want that the default workings directly impose nonnegativity constraints).
- If a user wants to override the automatic enforcing of non-negativity constraints, they can do so by manually setting `moment_lowerbounds` and then running `_update_lowerbounds()` (in contrast to just using `set_bounds()`).
- Also I have unified some functions regarding the processing of upper and lower bounds to avoid code duplications.

Tests have been redesigned and fixed to account for this. All tests pass in the PR, but a second (optionally third) pair of eyes would be valuable to confirm that I don't forget any desired functionality or that I forgot part of the motivation to use separate `_processed_moment_xxxerbounds` and `moment_xxxerbounds`.