### PR TITLE
Separate support problems from general problems

### DIFF
--- a/docs/examples.ipynb
+++ b/docs/examples.ipynb
@@ -1212,7 +1212,7 @@
     "Inflation can handle proofs of non-classicality and non-quantumness in arbitrary DAGs based on possibilistic arguments. It does so by assessing whether a quantum inflation (with commuting or non-commuting operators, respectively) exists where the probability elements inside the support are constrained to lie in the interval $[1,\\infty)$ while those outside the support are given the value $0$. This represents a rescaled version of a standard quantum inflation moment matrix, $\\Gamma^*=\\Gamma/\\epsilon$, that does not suffer of floating-point instabilities when determining if a probability element is outside the support or has assigned a very small value.\n",
     "To get back the original moment matrix $\\Gamma$, which contains probabilities as some of its cells, one just needs to divide $\\Gamma^*$ by the numerical value in its top-left corner, which corresponds to the rescaled value of the expectation value for the identity, $\\langle 1 \\rangle^*=1/\\epsilon$.\n",
     "\n",
-    "In order to deal with possibilistic feasibility problems, one must set the argument `supports_problem=True` when instantiating `InflationSDP`. Optimization of objective functions is not possible when assessing the feasibility of distribution supports.\n",
+    "In order to deal with possibilistic feasibility problems, one must instantiate a `SupportsSDP` object instead of `InflationSDP`. Optimization of objective functions is not possible when assessing the feasibility of distribution supports.\n",
     "\n",
     "### Example 10: Impossible distributions in the quantum instrumental scenario\n",
     "\n",
@@ -1236,7 +1236,7 @@
     }
    ],
    "source": [
-    "from inflation import InflationProblem, InflationSDP\n",
+    "from inflation import InflationProblem, SupportsSDP\n",
     "import numpy as np\n",
     "\n",
     "prob = InflationProblem(dag={\"rhoAB\": [\"A\", \"B\"],\n",
@@ -1244,7 +1244,7 @@
     "                        outcomes_per_party=(2, 2),\n",
     "                        settings_per_party=(3, 1))\n",
     "\n",
-    "sdp = InflationSDP(prob, supports_problem=True)\n",
+    "sdp = SupportsSDP(prob)\n",
     "sdp.generate_relaxation(\"local1\")\n",
     "\n",
     "def P(noise):\n",

--- a/docs/inflationsdp.rst
+++ b/docs/inflationsdp.rst
@@ -1,5 +1,10 @@
 InflationSDP Class
 ==================
 
+.. autoclass:: inflation.sdp.InflationSDP.BaseSDP
+   :members: generate_relaxation, set_distribution, set_values, solve, build_columns, reset, write_to_file
+
 .. autoclass:: inflation.InflationSDP
-   :members: generate_relaxation, set_bounds, set_distribution, set_objective, set_values, solve, build_columns, certificate_as_probs, certificate_as_string, reset, write_to_file
+   :members: set_bounds, set_objective, certificate_as_probs, certificate_as_string
+
+.. autoclass:: inflation.SupportsSDP

--- a/docs/monomials.rst
+++ b/docs/monomials.rst
@@ -10,4 +10,4 @@ Abstract monomial classes
 
 InflationSDP internal monomials
 -------------------------------
-.. autofunction:: inflation.InflationSDP.Monomial
+.. autofunction:: inflation.sdp.InflationSDP.BaseSDP.Monomial

--- a/inflation/__init__.py
+++ b/inflation/__init__.py
@@ -9,11 +9,12 @@ Provides
 """
 
 from .InflationProblem import InflationProblem
-from .sdp.InflationSDP import InflationSDP
+from .sdp.InflationSDP import InflationSDP, SupportsSDP
 from .sdp.optimization_utils import max_within_feasible
 from ._about import about
 from ._version import __version__
 
 __all__ = ["InflationProblem",
            "InflationSDP",
+           "SupportsSDP",
            "max_within_feasible"]

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -759,21 +759,24 @@ class BaseSDP(object):
             ``"upperbounds"``, ``"objective"``, ``"values"``, and ``"all"``.
         """
         if type(which) == str:
-            if which == "all":
-                self.reset(["bounds", "objective", "values"])
-            elif which == "bounds":
-                self._reset_bounds()
-            elif which == "lowerbounds":
-                self._reset_lowerbounds()
-            elif which == "upperbounds":
-                self._reset_upperbounds()
-            elif which == "objective":
-                self._reset_objective()
-            elif which == "values":
-                self._reset_values()
-            else:
-                raise Exception(f"The attribute {which} is not part of " +
-                                "InflationSDP.")
+            try:
+                if which == "all":
+                    self.reset(["bounds", "objective", "values"])
+                elif which == "bounds":
+                    self._reset_bounds()
+                elif which == "lowerbounds":
+                    self._reset_lowerbounds()
+                elif which == "upperbounds":
+                    self._reset_upperbounds()
+                elif which == "objective":
+                    self._reset_objective()
+                elif which == "values":
+                    self._reset_values()
+                else:
+                    raise Exception(f"The attribute {which} is not part of " +
+                                    "InflationSDP.")
+            except BaseException:
+                pass
         else:
             for attr in which:
                 self.reset(attr)
@@ -1929,37 +1932,6 @@ class InflationSDP(BaseSDP):
         cert += " < 0"
         return cert[1:] if cert[0] == "+" else cert
 
-    def reset(self, which: Union[str, List[str]]) -> None:
-        """Reset the various user-specifiable objects in the inflation SDP.
-
-        Parameters
-        ----------
-        which : Union[str, List[str]]
-            The objects to be reset. It can be fed as a single string or a list
-            of them. Options include ``"bounds"``, ``"lowerbounds"``,
-            ``"upperbounds"``, ``"objective"``, ``"values"``, and ``"all"``.
-        """
-        if type(which) == str:
-            if which == "all":
-                self.reset(["bounds", "objective", "values"])
-            elif which == "bounds":
-                self._reset_bounds()
-            elif which == "lowerbounds":
-                self._reset_lowerbounds()
-            elif which == "upperbounds":
-                self._reset_upperbounds()
-            elif which == "objective":
-                self._reset_objective()
-            elif which == "values":
-                self._reset_values()
-            else:
-                raise Exception(f"The attribute {which} is not part of " +
-                                "InflationSDP.")
-        else:
-            for attr in which:
-                self.reset(attr)
-        collect()
-
     ###########################################################################
     # HELPER FUNCTIONS FOR ENSURING CONSISTENCY                               #
     ###########################################################################
@@ -2077,37 +2049,6 @@ class SupportsSDP(BaseSDP):
         # Support problems do not use Collins-Gisin notation
         self.outcome_cardinalities = \
             self.InflationProblem.outcomes_per_party.copy() + 1
-
-    def reset(self, which: Union[str, List[str]]) -> None:
-        """Reset the various user-specifiable objects in the inflation SDP.
-
-        Parameters
-        ----------
-        which : Union[str, List[str]]
-            The objects to be reset. It can be fed as a single string or a list
-            of them. Options include ``"bounds"``, ``"lowerbounds"``,
-            ``"upperbounds"``, ``"objective"``, ``"values"``, and ``"all"``.
-        """
-        if type(which) == str:
-            if which == "all":
-                self.reset(["bounds", "objective", "values"])
-            elif which == "bounds":
-                self._reset_bounds()
-            elif which == "lowerbounds":
-                self._reset_lowerbounds()
-            elif which == "upperbounds":
-                self._reset_upperbounds()
-            elif which == "objective":
-                self._reset_objective()
-            elif which == "values":
-                self._reset_values()
-            else:
-                raise Exception(f"The attribute {which} is not part of " +
-                                "InflationSDP.")
-        else:
-            for attr in which:
-                self.reset(attr)
-        collect()
 
     def _generate_parties(self):
         # Support problems do not use Collins-Gisin notation

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -1690,8 +1690,10 @@ class BaseSDP(object):
                 self.canon_ndarray_from_hash[key] = array2d
                 return array2d
             else:
-                new_array2d = to_canonical(array2d, self._notcomm, self._lexorder,
-                                           self.commuting, apply_only_commutations)
+                new_array2d = to_canonical(array2d, self._notcomm,
+                                           self._lexorder,
+                                           self.commuting,
+                                           apply_only_commutations)
                 new_key = self._from_2dndarray(new_array2d)
                 self.canon_ndarray_from_hash[key]     = new_array2d
                 self.canon_ndarray_from_hash[new_key] = new_array2d

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -45,7 +45,7 @@ from .writer_utils import (write_to_csv,
 from ..utils import flatten
 
 
-class InflationSDP(object):
+class BaseSDP(object):
     """
     Class for generating and solving an SDP relaxation for quantum inflation.
 
@@ -56,9 +56,6 @@ class InflationSDP(object):
     commuting : bool, optional
         Whether variables in the problem are going to be commuting (classical
         problem) or non-commuting (quantum problem). By default ``False``.
-    supports_problem : bool, optional
-        Whether to consider feasibility problems with distributions, or just
-        with the distribution's support. By default ``False``.
     verbose : int, optional
         Optional parameter for level of verbose:
 
@@ -71,11 +68,21 @@ class InflationSDP(object):
     def __init__(self,
                  inflationproblem: InflationProblem,
                  commuting: bool = False,
-                 supports_problem: bool = False,
                  verbose=None) -> None:
         """Constructor for the InflationSDP class.
         """
-        self.supports_problem = supports_problem
+        pass
+
+
+class InflationSDP(BaseSDP):
+    constant_term_name = "constant_term"
+
+    def __init__(self,
+                 inflationproblem: InflationProblem,
+                 commuting: bool = False,
+                 supports_problem: bool = False,
+                 verbose=None) -> None:
+        super(InflationSDP, self).__init__(inflationproblem, commuting, verbose)
         if verbose is not None:
             if inflationproblem.verbose > verbose:
                 warn("Overriding the verbosity from InflationProblem")
@@ -2018,3 +2025,17 @@ class InflationSDP(object):
                 self.canon_ndarray_from_hash[key]     = new_array2d
                 self.canon_ndarray_from_hash[new_key] = new_array2d
                 return new_array2d
+
+
+class SupportsSDP(BaseSDP):
+    """
+    Class for generating and solving an SDP relaxation for quantum inflation
+    that tests whether the support of a distribution could be generated or not.
+
+    """
+    def __init__(self,
+                 inflationproblem: InflationProblem,
+                 commuting: bool = False,
+                 verbose=None) -> None:
+
+        super(SupportsSDP, self).__init__(inflationproblem, commuting, verbose)

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -48,6 +48,9 @@ from ..utils import flatten
 class BaseSDP(object):
     """
     Class for generating and solving an SDP relaxation for quantum inflation.
+    This is the base class with all of the common functionality to the
+    user-intended classes, namely :class:`InflationSDP` and
+    :class:`SupportsSDP`.
 
     Parameters
     ----------

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -2039,3 +2039,11 @@ class SupportsSDP(BaseSDP):
                  verbose=None) -> None:
 
         super(SupportsSDP, self).__init__(inflationproblem, commuting, verbose)
+
+    def _generate_parties(self):
+        # Support problems do not use Collins-Gisin notation
+        self.outcome_cardinalities = \
+            self.InflationProblem.outcomes_per_party + 1
+        measurements = super(SupportsSDP, self)._generate_parties()
+        return measurements
+

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -155,6 +155,7 @@ class BaseSDP(object):
         self.One  = self.Monomial(self.identity_operator, idx=1)
         self._relaxation_has_been_generated = False
         self.maximize = True
+        self.objective = {self.One: 0.}
 
     ###########################################################################
     # MAIN ROUTINES EXPOSED TO THE USER                                       #
@@ -2054,7 +2055,6 @@ class SupportsSDP(BaseSDP):
         # Support problems do not use Collins-Gisin notation
         self.outcome_cardinalities = \
             self.InflationProblem.outcomes_per_party.copy() + 1
-        self.objective = {self.One: 0.}
 
     def _generate_parties(self):
         # Support problems do not use Collins-Gisin notation

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -2049,6 +2049,7 @@ class SupportsSDP(BaseSDP):
         # Support problems do not use Collins-Gisin notation
         self.outcome_cardinalities = \
             self.InflationProblem.outcomes_per_party.copy() + 1
+        self.objective = {self.One: 0.}
 
     def _generate_parties(self):
         # Support problems do not use Collins-Gisin notation

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import warnings
 
-from inflation import InflationProblem, InflationSDP
+from inflation import InflationProblem, InflationSDP, SupportsSDP
 
 bilocalDAG = {"h1": ["A", "B"], "h2": ["B", "C"]}
 bilocality = InflationProblem(dag=bilocalDAG,
@@ -432,7 +432,7 @@ class TestSDPOutput(unittest.TestCase):
         self.assertEqual(sdp.status, "infeasible",
                          "Failing to detect the infeasibility of the " +
                          "distribution that maximally violates Bonet's " +
-                         "inequalty.")
+                         "inequality.")
         unnormalized_dist = np.ones((2, 2, 3, 1), dtype=float)
         sdp.set_distribution(unnormalized_dist)
         sdp.solve(feas_as_optim=False)
@@ -505,7 +505,7 @@ class TestSDPOutput(unittest.TestCase):
                         " LPI constraints are not assigned correct indices.")
 
     def test_supports(self):
-        sdp = InflationSDP(self.bellScenario, supports_problem=True)
+        sdp = SupportsSDP(self.bellScenario)
         sdp.generate_relaxation("local1")
         pr_support = np.zeros((2, 2, 2, 2))
         for a, b, x, y in np.ndindex(*pr_support.shape):


### PR DESCRIPTION
This PR separates the codes for general optimization problems and supports problems. This is done by creating two new classes, one `BaseSDP` that contains the bare minimum to create an SDP problem (and which is now a parent of `InflationSDP`), and `SupportsSDP` for supports problems. All tests pass, and documentation has been updated accordingly.

One (or two) pair of new eyes would be useful in case you want to test before merging. I am happy to take care of adapting the code so the merge can be performed.