### PR TITLE
Add support for DAGs with two-layer latents

### DIFF
--- a/docs/examples.ipynb
+++ b/docs/examples.ipynb
@@ -1138,7 +1138,7 @@
     "\n",
     "### Example 9: Feasibility and optimization in the instrumental scenario\n",
     "\n",
-    "The simplest causal scenario that exhibits a gap between classical, quantum and post-quantum correlations is the instrumental scenario [[9](https://arxiv.org/abs/1804.04119)]. The instrumental scenario features two parties, $A$ and $B$, that share a common source of correlations. While party $A$ can choose between different measurement settings, $x$, party $B$. However, party $A$ is allowed to signal their output to party $B$. The scenario is depicted as a DAG in Figure a) below. The associated network DAG is depicted in Figure b). The set of distributions $p(a,b|x)$ compatible with the non-network DAG of Figure a) is equivalent to the set of distributions $p(a,b|x,y{=}a)$ compatible with the network DAG of Figure b).\n",
+    "The simplest causal scenario that exhibits a gap between classical, quantum and post-quantum correlations is the instrumental scenario [[9](https://arxiv.org/abs/1804.04119)]. The instrumental scenario features two parties, $A$ and $B$, that share a common source of correlations. While party $A$ can choose between different measurement settings, $x$, party $B$ has no input choice. However, party $A$ is allowed to signal their output to party $B$. The scenario is depicted as a DAG in Figure a) below. The associated network DAG is depicted in Figure b). The set of distributions $p(a,b|x)$ compatible with the non-network DAG of Figure a) is equivalent to the set of distributions $p(a,b|x,y{=}a)$ compatible with the network DAG of Figure b).\n",
     "\n",
     "<center>\n",
     "<table><tr>\n",
@@ -1233,7 +1233,84 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that we have had to write $p(a, b{=}1\\vert x) = p(a \\vert x) - p(a, b{=}0\\vert x)$ explicitly. This is due to the fact that, internally, Inflation works with Collins-Gisin notation [[10](https://arxiv.org/abs/quant-ph/0306129)], and therefore some probability elements must be written in terms of the available ones. This is no different to the processing that we had to do in Example 3."
+    "Note that we have had to write $p(a, b{=}1\\vert x) = p(a \\vert x) - p(a, b{=}0\\vert x)$ explicitly. This is due to the fact that, internally, Inflation works with Collins-Gisin notation [[10](https://arxiv.org/abs/quant-ph/0306129)], and therefore some probability elements must be written in terms of the available ones. This is no different to the processing that we had to do in Example 3.\n",
+    "\n",
+    "### Example 10: Scenarios with multiple layers of latent nodes\n",
+    "\n",
+    "The instrumental scenario has a visible node (node $A$) with both parents and children. Internally, `inflation` handles these scenarios by adding an effective input to the children, and considering only the probabilities where the value of the node and the value of the effective input coincide. The remaining case is that of latent variables with both parents and children. These can be understood as joint operations on the incoming systems, which are later distributed forwards in the scenario. It is possible to characterize these scenarios in `inflation` by specifying `classical_intermediate_latents` and `nonclassical_intermediate_latents` in the `InflationProblem` constructor.\n",
+    "\n",
+    "As an example, let us recover some results of [[12](www.arxiv.org/abs/2403.02376)], regarding distributions that are generated in complex scenarios with multiple layers of latent nodes but cannot be generated in networks with only one layer of latent nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating the distribution in the multi-latent-layer network is feasible (a priori)\n",
+      "Generating the distribution in the single-latent-layer network is infeasible\n"
+     ]
+    }
+   ],
+   "source": [
+    "from inflation import InflationProblem, InflationSDP\n",
+    "import numpy as np\n",
+    "\n",
+    "# Distribution: noisy GHZ distribution for visibility 1/2\n",
+    "prob = np.zeros((2,2,2,2,2,2,1,1,1,1,1,1))\n",
+    "prob[0,0,0,0,0,0,0,0,0,0,0,0] = prob[1,1,1,1,1,1,0,0,0,0,0,0] = 27/128\n",
+    "prob[0,0,0,0,0,1,0,0,0,0,0,0] = prob[0,0,0,1,1,1,0,0,0,0,0,0] \\\n",
+    "= prob[0,1,1,1,1,1,0,0,0,0,0,0] = prob[1,0,0,0,0,0,0,0,0,0,0,0] \\\n",
+    "= prob[1,1,1,0,0,0,0,0,0,0,0,0] = prob[1,1,1,1,1,0,0,0,0,0,0,0] = 9/128\n",
+    "prob[0,0,0,1,1,1,0,0,0,0,0,0] = prob[0,1,1,0,0,0,0,0,0,0,0,0] \\\n",
+    "= prob[0,1,1,1,1,0,0,0,0,0,0,0] = prob[1,0,0,0,0,1,0,0,0,0,0] \\\n",
+    "= prob[1,0,0,1,1,1,0,0,0,0,0,0] = prob[1,1,1,0,0,1,0,0,0,0,0] = 3/128\n",
+    "prob[0,1,1,0,0,1,0,0,0,0,0,0] = prob[1,0,0,1,1,0,0,0,0,0,0,0] = 1/128\n",
+    "\n",
+    "# Non-network scenario. See Fig. 1b-ii of [12]\n",
+    "nonnetwork = InflationProblem(dag={\"S1\": [\"A1\", \"F1\"],\n",
+    "                                   \"S2\": [\"F1\", \"F2\"],\n",
+    "                                   \"S3\": [\"F2\", \"A6\"],\n",
+    "                                   \"F1\": [\"A2\", \"A3\"],\n",
+    "                                   \"F2\": [\"A4\", \"A5\"]\n",
+    "                                   },\n",
+    "                              order=(\"A1\", \"A2\", \"A3\", \"A4\", \"A5\", \"A6\"),\n",
+    "                              outcomes_per_party=(2, 2, 2, 2, 2, 2),\n",
+    "                              settings_per_party=(1, 1, 1, 1, 1, 1),\n",
+    "                              nonclassical_intermediate_latents=(\"F1\", \"F2\"),\n",
+    "                              inflation_level_per_source=[2, 2, 2]\n",
+    "                              )\n",
+    "\n",
+    "sdp = InflationSDP(nonnetwork)\n",
+    "sdp.generate_relaxation(\"npa1\")\n",
+    "\n",
+    "sdp.set_distribution(p)\n",
+    "sdp.solve()\n",
+    "print(\"Generating the distribution in the multi-latent-layer network is \"\n",
+    "      + sdp.status + \" (a priori)\")\n",
+    "\n",
+    "# Network scenario. See Fig. 1b-iii of [12]\n",
+    "network = InflationProblem(dag={\"S1\": [\"A1\", \"A2\", \"A3\", \"A4\"],\n",
+    "                                \"S2\": [\"A2\", \"A3\", \"A4\", \"A5\"],\n",
+    "                                \"S3\": [\"A3\", \"A4\", \"A5\", \"A6\"]\n",
+    "                                },\n",
+    "                           order=(\"A1\", \"A2\", \"A3\", \"A4\", \"A5\", \"A6\"),\n",
+    "                           outcomes_per_party=(2, 2, 2, 2, 2, 2),\n",
+    "                           settings_per_party=(1, 1, 1, 1, 1, 1),\n",
+    "                           inflation_level_per_source=[2, 2, 2]\n",
+    "                           )\n",
+    "\n",
+    "sdp = InflationSDP(network)\n",
+    "sdp.generate_relaxation(\"npa1\")\n",
+    "\n",
+    "sdp.set_distribution(p)\n",
+    "sdp.solve()\n",
+    "print(\"Generating the distribution in the single-latent-layer network is \"\n",
+    "      + sdp.status)\n"
    ]
   },
   {
@@ -1256,7 +1333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1265,7 +1342,7 @@
        "'infeasible'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1322,12 +1399,14 @@
     "\n",
     "[10] D. Collins and N. Gisin, *A Relevant Two Qubit Bell Inequality Inequivalent to the CHSH Inequality*, [J. Phys. A: Math. Gen. 37, 1775 (2004)](https://iopscience.iop.org/article/10.1088/0305-4470/37/5/021), [arXiv:quant-ph/0306129](https://arxiv.org/abs/quant-ph/0306129).\n",
     "\n",
-    "[11] S. Mansfield and T. Fritz., *Hardy's Non-locality Paradox and Possibilistic Conditions for Non-locality*, [Found. Phys. 42, 709–719 (2012)](https://link.springer.com/article/10.1007/s10701-012-9640-1), [arXiv:1105.1819](https://arxiv.org/abs/1105.1819).\n"
+    "[11] S. Mansfield and T. Fritz., *Hardy's Non-locality Paradox and Possibilistic Conditions for Non-locality*, [Found. Phys. 42, 709–719 (2012)](https://link.springer.com/article/10.1007/s10701-012-9640-1), [arXiv:1105.1819](https://arxiv.org/abs/1105.1819).\n",
+    "\n",
+    "[12] A. Ulibarrena, J. W. Webb, A. Pickston, J. Ho, A. Fedrizzi, and A. Pozas-Kerstjens, *Guarantees on the structure of experimental quantum networks*, [arXiv:2403.02376](https://arxiv.org/abs/2403.02376)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Examples of use of this package include:
 - Feasibility problems and extraction of certificates.
 - Optimization of Bell operators.
 - Optimization over classical distributions.
+- Handling of bilayer (i.e., networks) and multilayer causal structures.
 - Standard `Navascues-Pironio-Acin hierarchy <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.98.010401>`_.
 - Scenarios with partial information.
 - Possibilistic compatibility with a causal network.

--- a/inflation/InflationProblem.py
+++ b/inflation/InflationProblem.py
@@ -113,10 +113,16 @@ class InflationProblem:
             (self.outcomes_per_party,
              self.private_settings_per_party)).tolist())
 
+        # Internal record of intermediate latents
+        self.classical_intermediate_latents = set(map(str,classical_intermediate_latents))
+        self.nonclassical_intermediate_latents = set(map(str,nonclassical_intermediate_latents))
+        assert self.classical_intermediate_latents.isdisjoint(self.nonclassical_intermediate_latents), "An intermediate latent cannot be both classical and nonclassical."
+        self.intermediate_latents = self.classical_intermediate_latents.union(self.nonclassical_intermediate_latents)
+
         # Assign names to the visible variables
         names_have_been_set_yet = False
         if dag:
-            implicit_names = set(map(str, chain.from_iterable(dag.values()))).difference(nonclassical_intermediate_latents)
+            implicit_names = set(map(str, chain.from_iterable(dag.values()))).difference(self.intermediate_latents)
             assert len(implicit_names) == self.nr_parties, \
                 ("You must provide a number of outcomes for the following "
                  + f"{len(implicit_names)} variables: {implicit_names}")
@@ -162,12 +168,6 @@ class InflationProblem:
             # Sources are nodes with children but not parents
             self.dag = {str(parent): set(map(str, children)) for
                         parent, children in dag.items()}
-
-        # Internal record of intermediate latents
-        self.classical_intermediate_latents = set(classical_intermediate_latents)
-        self.nonclassical_intermediate_latents = set(nonclassical_intermediate_latents)
-        assert self.classical_intermediate_latents.isdisjoint(self.nonclassical_intermediate_latents), "An intermediate latent cannot be both classical and nonclassical."
-        self.intermediate_latents = self.classical_intermediate_latents.union(self.nonclassical_intermediate_latents)
 
 
         # Distinguishing between classical versus nonclassical sources

--- a/inflation/InflationProblem.py
+++ b/inflation/InflationProblem.py
@@ -252,7 +252,9 @@ class InflationProblem:
                     self.hypergraph[source_idx, desc_idx] = 1
                     for desc2 in observable_descendants_via_this_latent:
                         desc2_idx = names_to_integers[desc2]
-                        self.sources_to_check_for_party_pair_commutation[desc_idx, desc2_idx, source_idx] = 1 + quantum_connection_bonus
+                        self.sources_to_check_for_party_pair_commutation[desc_idx, desc2_idx, source_idx] = max(
+                        self.sources_to_check_for_party_pair_commutation[desc_idx, desc2_idx, source_idx],
+                            1 + quantum_connection_bonus)
 
 
         assert np.sum(self.hypergraph, axis=0).all(), \

--- a/inflation/InflationProblem.py
+++ b/inflation/InflationProblem.py
@@ -368,6 +368,7 @@ class InflationProblem:
         if self._nonclassical_sources.any():
             self._default_notcomm = commutation_matrix(self._lexorder,
                                                        self._nonclassical_sources,
+                                                       self.sources_to_check_for_party_pair_commutation,
                                                        False)
         else:
             self._default_notcomm = np.zeros(

--- a/test/test_monomial_properties.py
+++ b/test/test_monomial_properties.py
@@ -112,32 +112,40 @@ class TestToCanonical(unittest.TestCase):
         
         # Two source scenario. Two operators with overlap on the first source, 
         # with the first source being classical.
+        # No intermediate latents.
+        pairwise_source_info = np.zeros((2, 2, 2), dtype=bool)
+        for i in range(2):
+            pairwise_source_info[i, i] = True
         self.assertFalse(nb_operators_commute(
-                            np.array([1, 1, 1, 0, 0]),
-                            np.array([1, 1, 2, 0, 0]),
-                            np.array([1, 1], dtype=bool)),  # both sources quantum
-                        "nb_operators_commute fails to identify " +
-                        "non-commutativty when overlapping on quantum sources.")
+            np.array([1, 1, 1, 0, 0]),
+            np.array([1, 1, 2, 0, 0]),
+            np.array([1, 1], dtype=bool),  # both sources quantum
+            sources_to_check_for_pairwise=pairwise_source_info),
+            "nb_operators_commute fails to identify " +
+            "non-commutativty when overlapping on quantum sources.")
         self.assertTrue(nb_operators_commute(
-                            np.array([1, 1, 1, 0, 0]),
-                            np.array([1, 1, 2, 0, 0]),
-                            np.array([0, 1], dtype=bool)),  # first source classical
-                        "nb_operators_commute fails to identify " +
-                        "commutativity when overlapping on classical sources.")
+            np.array([1, 1, 1, 0, 0]),
+            np.array([1, 1, 2, 0, 0]),
+            np.array([0, 1], dtype=bool),  # first source classical
+            sources_to_check_for_pairwise=pairwise_source_info),
+            "nb_operators_commute fails to identify " +
+            "commutativity when overlapping on classical sources.")
         self.assertTrue(nb_operators_commute(
-                            np.array([1, 1, 1, 0, 0]),
-                            np.array([1, 1, 2, 1, 0]),
-                            np.array([0, 1], dtype=bool)),  # first source classical
-                        "nb_operators_commute fails to identify " +
-                        "commutativity when overlapping on classical sources "+
-                        "with different settings for the operators.")
+            np.array([1, 1, 1, 0, 0]),
+            np.array([1, 1, 2, 1, 0]),
+            np.array([0, 1], dtype=bool),  # first source classical
+            sources_to_check_for_pairwise=pairwise_source_info),
+            "nb_operators_commute fails to identify " +
+            "commutativity when overlapping on classical sources " +
+            "with different settings for the operators.")
         self.assertTrue(nb_operators_commute(
-                            np.array([1, 1, 1, 0, 0]),
-                            np.array([1, 1, 1, 1, 0]),
-                            np.array([0, 0], dtype=bool)),  # both sources classical
-                        "nb_operators_commute fails to identify " +
-                        "commutativity when overlapping on classical sources "+
-                        "with different settings for the operators.")
+            np.array([1, 1, 1, 0, 0]),
+            np.array([1, 1, 1, 1, 0]),
+            np.array([0, 0], dtype=bool),  # both sources classical
+            sources_to_check_for_pairwise=pairwise_source_info),
+            "nb_operators_commute fails to identify " +
+            "commutativity when overlapping on classical sources " +
+            "with different settings for the operators.")
         
 
 

--- a/test/test_monomial_properties.py
+++ b/test/test_monomial_properties.py
@@ -195,7 +195,7 @@ class TestToRepr(unittest.TestCase):
 class TestCommutations(unittest.TestCase):
     scenario = InflationProblem(dag={"s1": ["A", "B", "l1", "l2"],
                                      "s2": ["C", "D"],
-                                     "s3": ["l2"],
+                                     "s3": ["l1", "l2"],
                                      "l1": ["C", "D"],
                                      "l2": ["B", "E"]},
                                 outcomes_per_party=[2, 2, 2, 2, 2],
@@ -262,30 +262,32 @@ class TestCommutations(unittest.TestCase):
         # The CD case. Here we only have commutation if the nonclassical copies
         # are disjoint
         op1_init = np.where(np.all(self.order == self.meas[2][0,0,0], axis=1))[0]
-        op1_end  = np.where(np.all(self.order == self.meas[2][3,-1,-1], axis=1))[0]
-        op2_init = np.where(np.all(self.order == self.meas[3][-4,0,0], axis=1))[0]
+        op1_end  = np.where(np.all(self.order == self.meas[2][0,-1,-1], axis=1))[0]
+        op2_init = np.where(np.all(self.order == self.meas[3][-1,0,0], axis=1))[0]
         op2_end  = np.where(np.all(self.order == self.meas[3][-1,-1,-1], axis=1))[0]
         op1_init, op1_end = op1_init.item(), op1_end.item()
         op2_init, op2_end = op2_init.item(), op2_end.item()
         self.assertEqual(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1].sum(),
                          0,
                          "Operators for separate parties with classical and " \
-                         + " nonclassical parents do not commute when " \
+                         + "nonclassical parents do not commute when " \
                          + "measuring on different nonclassical copies.")
 
     def test_nonclassical_latent(self):
         # When two parties share a common nonclassical latent ancestor, their
-        # operators over the exact same copies do not commute.
+        # operators do not commute only when the quantum copy indices partially
+        # overlap.
         op1_init = np.where(np.all(self.order == self.meas[2][0,0,0], axis=1))[0]
         op1_end  = np.where(np.all(self.order == self.meas[2][0,-1,-1], axis=1))[0]
-        op2_init = np.where(np.all(self.order == self.meas[3][0,0,0], axis=1))[0]
-        op2_end  = np.where(np.all(self.order == self.meas[3][0,-1,-1], axis=1))[0]
+        op2_init = np.where(np.all(self.order == self.meas[3][1,0,0], axis=1))[0]
+        op2_end  = np.where(np.all(self.order == self.meas[3][1,-1,-1], axis=1))[0]
         op1_init, op1_end = op1_init.item(), op1_end.item()
         op2_init, op2_end = op2_init.item(), op2_end.item()
+        print(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1])
         self.assertTrue(
             np.all(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1]),
-            "Operators for parties with a common nonclassical latent " + \
-            "ancestor commute for same nonclassical copies.")
+            "Operators for parties with common nonclassical latent " + \
+            "ancestors commute for partially overlapping nonclassical copies.")
 
     def test_classical_latent(self):
         # When two parties share a common classical latent ancestor, their

--- a/test/test_monomial_properties.py
+++ b/test/test_monomial_properties.py
@@ -191,3 +191,113 @@ class TestToRepr(unittest.TestCase):
         self.assertEqual(self.sdp_noncommuting._sanitise_moment(initial),
                          self.sdp_noncommuting._sanitise_moment(correct),
                          "Swapping a single source fails.")
+
+class TestCommutations(unittest.TestCase):
+    scenario = InflationProblem(dag={"s1": ["A", "B", "l1", "l2"],
+                                     "s2": ["C", "D"],
+                                     "s3": ["l2"],
+                                     "l1": ["C", "D"],
+                                     "l2": ["B", "E"]},
+                                outcomes_per_party=[2, 2, 2, 2, 2],
+                                settings_per_party=[2, 2, 2, 2, 2],
+                                inflation_level_per_source=[2, 2, 2],
+                                classical_sources=["s2"],
+                                nonclassical_intermediate_latents=["l1"],
+                                classical_intermediate_latents=["l2"])
+    notcomm = scenario._default_notcomm
+    meas    = scenario.measurements
+    order   = scenario._lexorder
+    
+    def test_commute_itself(self):
+        # All operators should commute with themselves.
+        self.assertEqual(self.notcomm.diagonal().sum(),
+                         0,
+                         "Some operator does not commute with itself.")
+    
+    def test_same_nonclassical(self):
+        # The operators corresponding to different measurements of a same party
+        # fed by nonclassical sources do not commute. Take for example A.
+        op1_init = np.where(np.all(self.order == self.meas[0][0,0,0], axis=1))[0]
+        op1_end  = np.where(np.all(self.order == self.meas[0][0,0,-1], axis=1))[0]
+        op2_init = np.where(np.all(self.order == self.meas[0][0,-1,0], axis=1))[0]
+        op2_end  = np.where(np.all(self.order == self.meas[0][0,-1,-1], axis=1))[0]
+        op1_init, op1_end = op1_init.item(), op1_end.item()
+        op2_init, op2_end = op2_init.item(), op2_end.item()
+        self.assertTrue(
+            np.all(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1]),
+            "Operators for different measurement of a same party commute.")
+        
+    def test_same_classical(self):
+        # All operators corresponding to a same party fed by classical sources
+        # commute. Take for example E.
+        op1_init = np.where(np.all(self.order == self.meas[-1][0,0,0], axis=1))[0]
+        op1_end  = np.where(np.all(self.order == self.meas[-1][-1,-1,-1], axis=1))[0]
+        op1_init, op1_end = op1_init.item(), op1_end.item()
+        self.assertEqual(
+            np.sum(self.notcomm[op1_init:op1_end+1, op1_init:op1_end+1]),
+            0,
+            "Operators of a classical party do not commute.")
+
+    def test_source_parties(self):
+        # We restrict to the case of parties connected (or not) by a source.
+        # Regardless of the nature of the sources, they should commute. This
+        # applies to all pairs of parties, except BE (connected by a classical
+        # latent, tretated later), and CD (connected by a quantum latent and a
+        # classical source, so they only commute if the nonclassical copies do
+        # not overlap, treated later)
+        for pair in [[0, 1], [0, 2], [0, 3], [0, 4],
+                     [1, 2], [1, 3], [2, 4], [3, 4]]:
+            op1_init = np.where(np.all(self.order == self.meas[pair[0]][0,0,0], axis=1))[0]
+            op1_end  = np.where(np.all(self.order == self.meas[pair[0]][-1,-1,-1], axis=1))[0]
+            op2_init = np.where(np.all(self.order == self.meas[pair[1]][0,0,0], axis=1))[0]
+            op2_end  = np.where(np.all(self.order == self.meas[pair[1]][-1,-1,-1], axis=1))[0]
+            op1_init, op1_end = op1_init.item(), op1_end.item()
+            op2_init, op2_end = op2_init.item(), op2_end.item()
+            self.assertEqual(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1].sum(),
+                             0,
+                             "Operators for separate parties " + \
+                             f"{chr(65+pair[0])} and {chr(65+pair[1])} do not commute.")
+    
+    def test_classical_nonclassical_sources(self):
+        # The CD case. Here we only have commutation if the nonclassical copies
+        # are disjoint
+        op1_init = np.where(np.all(self.order == self.meas[2][0,0,0], axis=1))[0]
+        op1_end  = np.where(np.all(self.order == self.meas[2][3,-1,-1], axis=1))[0]
+        op2_init = np.where(np.all(self.order == self.meas[3][-4,0,0], axis=1))[0]
+        op2_end  = np.where(np.all(self.order == self.meas[3][-1,-1,-1], axis=1))[0]
+        op1_init, op1_end = op1_init.item(), op1_end.item()
+        op2_init, op2_end = op2_init.item(), op2_end.item()
+        self.assertEqual(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1].sum(),
+                         0,
+                         "Operators for separate parties with classical and " \
+                         + " nonclassical parents do not commute when " \
+                         + "measuring on different nonclassical copies.")
+
+    def test_nonclassical_latent(self):
+        # When two parties share a common nonclassical latent ancestor, their
+        # operators over the exact same copies do not commute.
+        op1_init = np.where(np.all(self.order == self.meas[2][0,0,0], axis=1))[0]
+        op1_end  = np.where(np.all(self.order == self.meas[2][0,-1,-1], axis=1))[0]
+        op2_init = np.where(np.all(self.order == self.meas[3][0,0,0], axis=1))[0]
+        op2_end  = np.where(np.all(self.order == self.meas[3][0,-1,-1], axis=1))[0]
+        op1_init, op1_end = op1_init.item(), op1_end.item()
+        op2_init, op2_end = op2_init.item(), op2_end.item()
+        self.assertTrue(
+            np.all(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1]),
+            "Operators for parties with a common nonclassical latent " + \
+            "ancestor commute for same nonclassical copies.")
+
+    def test_classical_latent(self):
+        # When two parties share a common classical latent ancestor, their
+        # operators should always commute. This is the case for BE.
+        op1_init = np.where(np.all(self.order == self.meas[1][0,0,0], axis=1))[0]
+        op1_end  = np.where(np.all(self.order == self.meas[1][-1,-1,-1], axis=1))[0]
+        op2_init = np.where(np.all(self.order == self.meas[4][0,0,0], axis=1))[0]
+        op2_end  = np.where(np.all(self.order == self.meas[4][-1,-1,-1], axis=1))[0]
+        op1_init, op1_end = op1_init.item(), op1_end.item()
+        op2_init, op2_end = op2_init.item(), op2_end.item()
+        self.assertEqual(
+            np.sum(self.notcomm[op1_init:op1_end+1, op2_init:op2_end+1]),
+            0,
+            "Operators for parties with a common classical latent ancestor " + \
+            "do not commute.")

--- a/test/test_monomial_properties.py
+++ b/test/test_monomial_properties.py
@@ -113,36 +113,36 @@ class TestToCanonical(unittest.TestCase):
         # Two source scenario. Two operators with overlap on the first source, 
         # with the first source being classical.
         # No intermediate latents.
-        pairwise_source_info = np.zeros((2, 2, 2), dtype=bool)
+        pairwise_source_info_both_classical = np.zeros((2, 2, 2), dtype=np.uint8)
+        pairwise_source_info_both_quantum = np.zeros((2, 2, 2), dtype=np.uint8)
+        pairwise_source_info_first_classical = np.zeros((2, 2, 2), dtype=np.uint8)
         for i in range(2):
-            pairwise_source_info[i, i] = True
+            pairwise_source_info_both_classical[i, i] = [1, 1]
+            pairwise_source_info_both_quantum[i, i] = [2, 2]
+            pairwise_source_info_first_classical[i, i] = [1, 2]
         self.assertFalse(nb_operators_commute(
             np.array([1, 1, 1, 0, 0]),
             np.array([1, 1, 2, 0, 0]),
-            np.array([1, 1], dtype=bool),  # both sources quantum
-            sources_to_check_for_pairwise=pairwise_source_info),
+            sources_to_check_for_pairwise=pairwise_source_info_both_quantum),
             "nb_operators_commute fails to identify " +
             "non-commutativty when overlapping on quantum sources.")
         self.assertTrue(nb_operators_commute(
             np.array([1, 1, 1, 0, 0]),
             np.array([1, 1, 2, 0, 0]),
-            np.array([0, 1], dtype=bool),  # first source classical
-            sources_to_check_for_pairwise=pairwise_source_info),
+            sources_to_check_for_pairwise=pairwise_source_info_first_classical),
             "nb_operators_commute fails to identify " +
             "commutativity when overlapping on classical sources.")
         self.assertTrue(nb_operators_commute(
             np.array([1, 1, 1, 0, 0]),
             np.array([1, 1, 2, 1, 0]),
-            np.array([0, 1], dtype=bool),  # first source classical
-            sources_to_check_for_pairwise=pairwise_source_info),
+            sources_to_check_for_pairwise=pairwise_source_info_first_classical),
             "nb_operators_commute fails to identify " +
             "commutativity when overlapping on classical sources " +
             "with different settings for the operators.")
         self.assertTrue(nb_operators_commute(
             np.array([1, 1, 1, 0, 0]),
             np.array([1, 1, 1, 1, 0]),
-            np.array([0, 0], dtype=bool),  # both sources classical
-            sources_to_check_for_pairwise=pairwise_source_info),
+            sources_to_check_for_pairwise=pairwise_source_info_both_classical),
             "nb_operators_commute fails to identify " +
             "commutativity when overlapping on classical sources " +
             "with different settings for the operators.")


### PR DESCRIPTION
@eliewolfe added support for handling DAGs with two layers of latent variables (understood as one layer of sources, and one layer of processings). This translates into modifications of the commutation relations between operators which have an intermediate latent as common ancestor. The implementation is nice, documentation is written, and so are tests.

Before merging, I have two questions:

- Do we want to add an example to the documentation where we illustrate the new functionality? I guess that the answer is yes.
- Do we have a simple example where to illustrate the new functionality, and which we can show without scooping a potential paper? ;)