### PR TITLE
Add ability to evaluate certificates in distributions

### DIFF
--- a/docs/examples.ipynb
+++ b/docs/examples.ipynb
@@ -582,7 +582,7 @@
      "text": [
       "Critical visibility: 0.70709228515625 \n",
       "Certificate:\n",
-      "pA(0|0) - pAB(00|00) - pAB(00|01) - pAB(00|10) + pAB(00|11) + pB(0|0) + 0.207\n"
+      "1.0-4.828*pAB(00|00)+4.828*pA(0|0)-4.828*pAB(00|01)-4.828*pAB(00|10)+4.828*pB(0|0)+4.828*pAB(00|11) < 0\n"
      ]
     }
    ],
@@ -610,11 +610,11 @@
     "    return vis * p + (1 - vis) * np.ones(p.shape) / 2 ** 2\n",
     "\n",
     "sdp.set_distribution(P_PRbox(Symbol(\"v\")))\n",
-    "v, cert = max_within_feasible(sdp,\n",
-    "                              sdp.known_moments,\n",
-    "                              \"bisection\",\n",
-    "                              return_last_certificate=True)\n",
-    "print(\"Critical visibility:\", v, f\"\\nCertificate:\\n{cert}\")"
+    "v = max_within_feasible(sdp,\n",
+    "                        sdp.known_moments,\n",
+    "                        \"bisection\")\n",
+    "print(\"Critical visibility:\", v,\n",
+    "      f\"\\nCertificate:\\n{sdp.certificate_as_string(chop_tol=1e-4)}\")"
    ]
   },
   {
@@ -625,7 +625,7 @@
     }
    },
    "source": [
-    "Notice that the dual certificate that we extract is the well-known CHSH inequality tangent to the quantum set of correlations, modulo a global factor of 4. We can see that this is indeed the case. For doing so, we write the resulting expression in correlators:"
+    "Notice that the dual certificate that we extract is the well-known CHSH inequality tangent to the quantum set of correlations, modulo a global factor. We can see that this is indeed the case. For doing so, we write the resulting expression in correlators:"
    ]
   },
   {
@@ -652,6 +652,8 @@
     "l, r = r\"\\langle \", r\"\\rangle\"\n",
     "from sympy import Symbol\n",
     "prob_to_corr = {}\n",
+    "\n",
+    "cert = sdp.certificate_as_probs(chop_tol=1e-4)\n",
     "for prob in cert.free_symbols:\n",
     "    inputs  = str(prob).split(\"|\")[-1][:-1]\n",
     "    parties = str(prob).split(\"(\")[0][1:]\n",
@@ -665,7 +667,7 @@
     "             + Symbol(l + parties[0] + \"_{\"+inputs[0]+\"}\" +\n",
     "                      parties[1] + \"_{\"+inputs[1]+\"}\" + r)) / 4\n",
     "        \n",
-    "4*cert.subs(prob_to_corr)"
+    "0.8285*cert.subs(prob_to_corr)"
    ]
   },
   {
@@ -1415,10 +1417,10 @@
      "text": [
       "\n",
       "Inflation: Implementations of the Inflation Technique for Causal Inference\n",
-      "================================================================================\n",
+      "==============================================================================\n",
       "Authored by: Emanuel-Cristian Boghiu, Elie Wolfe and Alejandro Pozas-Kerstjens\n",
       "\n",
-      "Inflation Version:\t0.1\n",
+      "Inflation Version:\t1.1.0\n",
       "\n",
       "Core Dependencies\n",
       "-----------------\n",

--- a/docs/examples.ipynb
+++ b/docs/examples.ipynb
@@ -152,14 +152,10 @@
    ],
    "source": [
     "# 2PR distribution\n",
-    "print(cert.subs({mon.symbol: val\n",
-    "                 for mon, val in sdp.known_moments.items()}))\n",
+    "print(sdp.evaluate_certificate(P_2PR()))\n",
     "\n",
     "# Uniform distribution\n",
-    "uniform = {mon.symbol: 1 / 2 ** mon.n_operators\n",
-    "           for mon in sdp.known_moments.keys()\n",
-    "           if mon.is_atomic}\n",
-    "print(cert.subs(uniform))"
+    "print(sdp.evaluate_certificate(np.ones_like(P_2PR()) / 8))"
    ]
   },
   {

--- a/docs/inflationlp.rst
+++ b/docs/inflationlp.rst
@@ -2,4 +2,4 @@ InflationLP Class
 ==================
 
 .. autoclass:: inflation.InflationLP
-   :members: _generate_lp, set_bounds, set_distribution, set_objective, set_values, update_values, solve, certificate_as_probs, certificate_as_probs, certificate_as_string, reset, write_to_file
+   :members: _generate_lp, set_bounds, set_distribution, set_objective, set_values, update_values, solve, certificate_as_probs, certificate_as_probs, certificate_as_string, evaluate_certificate, reset, write_to_file

--- a/docs/inflationsdp.rst
+++ b/docs/inflationsdp.rst
@@ -2,4 +2,4 @@ InflationSDP Class
 ==================
 
 .. autoclass:: inflation.InflationSDP
-   :members: generate_relaxation, set_bounds, set_distribution, set_objective, set_values, solve, build_columns, certificate_as_probs, certificate_as_string, reset, write_to_file
+   :members: generate_relaxation, set_bounds, set_distribution, set_objective, set_values, solve, build_columns, certificate_as_probs, certificate_as_string, evaluate_certificate, reset, write_to_file

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -757,6 +757,40 @@ class InflationLP(object):
                         cert += f"{abs(coeff)}*{mon_name}"
         cert += " < 0"
         return cert[1:] if cert[0] == "+" else cert
+    
+    def evaluate_certificate(self, prob_array):
+        """Evaluate the certificate of infeasibility in a target probability
+        distribution. If the evaluation is a negative value, the distribution is
+        not compatible with the causal structure. Warning: when using
+        ``use_lpi_constraints=True`` the set of constraints depends on the
+        specified distribution, thus the certificate is not guaranteed to apply.
+
+        Parameters
+        ----------
+        prob_array : numpy.ndarray
+            Multidimensional array encoding the distribution, which is
+            called as ``prob_array[a,b,c,...,x,y,z,...]`` where
+            :math:`a,b,c,\dots` are outputs and :math:`x,y,z,\dots` are
+            inputs. Note: even if the inputs have cardinality 1 they must
+            be specified, and the corresponding axis dimensions are 1.
+            The parties' outcomes and measurements must be appear in the
+            same order as specified by the ``order`` parameter in the
+            ``InflationProblem`` used to instantiate ``InflationLP``.
+
+        Returns
+        -------
+        float
+            The evaluation of the certificate of infeasibility in prob_array.
+        """
+        if self.use_lpi_constraints:
+            warn("You have used LPI constraints to obtain the certificate. " +
+                 "Be aware that, because of that, the certificate may not be " +
+                 "valid for other distributions.")
+        cert = self.certificate_as_dict()
+        eval = 0
+        for atom, val in cert.items():
+            eval += atom.compute_marginal(prob_array) * val
+        return eval
 
     ###########################################################################
     # OTHER ROUTINES EXPOSED TO THE USER                                      #

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -697,20 +697,11 @@ class InflationLP(object):
                 round_decimals=round_decimals))
 
     def string_from_dict(self,
-                         dict_with_monomial_keys: dict,
-                         clean: bool = True,
-                         round_decimals: int = 3) -> str:
+                         dict_with_monomial_keys) -> str:
         """Converts a monomial dictionary into a string.
 
         Parameters
         ----------
-        clean : bool, optional
-            If ``True``, eliminate all coefficients that are smaller than
-            ``chop_tol``, normalise and round to the number of decimals
-            specified by ``round_decimals``. By default ``True``.
-        round_decimals : int, optional
-            Coefficients that are not set to zero are formatted to the number
-            of decimals specified. By default ``3``.
         dict_with_monomial_keys : Dict[sympy.Symbol, float]
             Dictionary with monomials and associated coefficients.
 
@@ -719,31 +710,26 @@ class InflationLP(object):
         str
             The expression of the certificate in string form.
         """
-        chop_tol = 10 ** (-round_decimals)
         as_dict = self._sanitise_dict(dict_with_monomial_keys)
-        if clean:
-            as_dict = clean_coefficients(as_dict, chop_tol, round_decimals)
         # Watch out for when "1" is note the same as "constant_term"
         constant_value = as_dict.pop(self.Constant_Term,
                                      as_dict.pop(self.One, 0.)
                                      )
         if constant_value:
-            polynomial_as_str = "{0:.{prec}f}".format(constant_value,
-                                         prec=round_decimals)
+            polynomial_as_str = str(constant_value)
         else:
             polynomial_as_str = ""
         for mon, coeff in as_dict.items():
-            if mon.is_zero or np.abs(coeff) <= chop_tol:
+            if mon.is_zero or np.isclose(np.abs(coeff), 0):
                 continue
             else:
                 polynomial_as_str += "+" if coeff >= 0 else "-"
                 if np.isclose(abs(coeff), 1):
                     polynomial_as_str += mon.name
                 else:
-                    polynomial_as_str += "{0:.{prec}f}*{1}".format(abs(coeff),
-                                                      mon.name,
-                                                      prec=round_decimals)
-        return polynomial_as_str[1:] if polynomial_as_str[0] == "+" else polynomial_as_str
+                    polynomial_as_str += "{0}*{1}".format(abs(coeff), mon.name)
+        return polynomial_as_str[1:] if polynomial_as_str[0
+                                            ] == "+" else polynomial_as_str
 
     def certificate_as_string(self,
                               clean: bool = True,
@@ -783,9 +769,7 @@ class InflationLP(object):
             self.certificate_as_dict(
                 clean=clean,
                 chop_tol=chop_tol,
-                round_decimals=round_decimals),
-            round_decimals=round_decimals,
-            clean=False) + " < 0"
+                round_decimals=round_decimals)) + " < 0"
 
     def evaluate_polynomial(self, polynomial: dict, prob_array: np.ndarray):
         """Evaluate the certificate of infeasibility in a target probability

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -639,8 +639,20 @@ class InflationLP(object):
         return {self.monomial_from_name[k]: v for k, v in dual.items()
                 if not self.monomial_from_name[k].is_zero}
 
-    def probs_from_dict(self, dict_with_monomial_keys: dict) -> sp.core.add.Add:
-        "Converts a monomial dictionary into a SymPy expression."
+    def probs_from_dict(self,
+                        dict_with_monomial_keys: dict) -> sp.core.add.Add:
+        """Converts a monomial dictionary into a SymPy expression.
+
+        Parameters
+        ----------
+        dict_with_monomial_keys : Dict[sympy.Symbol, float]
+            Dictionary with monomials and associated coefficients.
+
+        Returns
+        -------
+        sympy.core.add.Add
+            The expression of the polynomial encoded in the dictionary.
+        """
         polynomial = sp.S.Zero
         for mon, coeff in self._sanitise_dict(dict_with_monomial_keys).items():
             polynomial += coeff * mon.symbol
@@ -689,6 +701,7 @@ class InflationLP(object):
                          clean: bool = True,
                          round_decimals: int = 3) -> str:
         """Converts a monomial dictionary into a string.
+
         Parameters
         ----------
         clean : bool, optional
@@ -698,12 +711,19 @@ class InflationLP(object):
         round_decimals : int, optional
             Coefficients that are not set to zero are formatted to the number
             of decimals specified. By default ``3``.
+        dict_with_monomial_keys : Dict[sympy.Symbol, float]
+            Dictionary with monomials and associated coefficients.
+
+        Returns
+        -------
+        str
+            The expression of the certificate in string form.
         """
         chop_tol = 10 ** (-round_decimals)
         as_dict = self._sanitise_dict(dict_with_monomial_keys)
         if clean:
             as_dict = clean_coefficients(as_dict, chop_tol, round_decimals)
-        # Watch out for when "1" is note the same as "constant_term
+        # Watch out for when "1" is note the same as "constant_term"
         constant_value = as_dict.pop(self.Constant_Term,
                                      as_dict.pop(self.One, 0.)
                                      )

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -592,7 +592,7 @@ class InflationLP(object):
     def certificate_as_dict(self,
                              clean: bool = True,
                              chop_tol: float = 1e-10,
-                             round_decimals: int = 3) -> sp.core.add.Add:
+                             round_decimals: int = 3) -> dict:
         """Give certificate as dictionary with monomials as keys and
         their coefficients in the certificate as the values. The certificate
         of incompatibility is ``cert < 0``.

--- a/inflation/lp/monomial_classes.py
+++ b/inflation/lp/monomial_classes.py
@@ -387,3 +387,14 @@ class CompoundMoment(object):
                 if np.isclose(known_value, 0):
                     known_status = "Known"
         return known_value, unknown_factors, known_status
+
+    def __copy__(self):
+        """Make a copy of the CompoundMonomial"""
+        cls = self.__class__
+        result = cls.__new__(cls)
+        for attr in self.__slots__:
+            try:
+                result.__setattr__(attr, self.__getattribute__(attr))
+            except AttributeError:
+                pass
+        return result

--- a/inflation/optimization_utils.py
+++ b/inflation/optimization_utils.py
@@ -25,7 +25,7 @@ def max_within_feasible(program: Union[InflationLP, InflationSDP],
                         method: str,
                         return_last_certificate=False,
                         **kwargs) -> Union[float,
-                                           Tuple[float, sp.core.add.Add]]:
+                                           Tuple[float, dict]]:
     """Maximize a single real variable within the set of feasible moment
     matrices determined by an ``InflationSDP``. The dependence of the moment
     matrices in the variable is specified by an assignment of monomials in the
@@ -62,7 +62,7 @@ def max_within_feasible(program: Union[InflationLP, InflationSDP],
         distributions compatible with an inflation (for LPs) or under the set of
         positive-semidefinite moment matrices (for SDPs). This is the output
         when ``return_last_certificate=False``.
-    Tuple[float, sympy.core.add.Add]
+    Tuple[float, dict]
         The maximum value that the parameter can take under the set of
         distributions compatible with an inflation (for LPs) or under the set of
         positive-semidefinite moment matrices (for SDPs), and a corresponding
@@ -164,8 +164,8 @@ def _maximize_via_bisect(program: Union[InflationLP, InflationSDP],
         if verbose:
             print(f"Parameter = {value:<6.4g}   " +
                   f"Maximum smallest eigenvalue: {program.objective_value:10.4g}")
-        discovered_certificate = program.certificate_as_probs()
-        if discovered_certificate.free_symbols:
+        discovered_certificate = program.certificate_as_dict()
+        if len(discovered_certificate):  # Checking if certificate has any nonzero coefficients
             discovered_certificates.append((value, discovered_certificate))
         return program.objective_value+precision/2048
     crit_param = bisect(f, bounds[0], bounds[1], **bisect_kwargs, full_output=False)
@@ -209,7 +209,7 @@ def _maximize_via_dual(program: Union[InflationLP, InflationSDP],
         distributions compatible with an inflation (for LPs) or under the set of
         positive-semidefinite moment matrices (for SDPs). This is the output
         when ``return_last_certificate=False``.
-    Tuple[float, sympy.core.add.Add]
+    Tuple[float, dict]
         The maximum value that the parameter can take under the set of
         distributions compatible with an inflation (for LPs) or under the set of
         positive-semidefinite moment matrices (for SDPs), and a corresponding
@@ -261,7 +261,7 @@ def _maximize_via_dual(program: Union[InflationLP, InflationSDP],
                             constraints=constraints,
                             options={'disp': False})
         new_ub = solution['x'][0]
-        discovered_certificates.append((new_ub , program.certificate_as_probs()))
+        discovered_certificates.append((new_ub , program.certificate_as_dict()))
         if verbose:
             print(f"Current critical value: {new_ub} (seeded by {old_ub+precision})")
     crit_param = max(new_ub, old_ub)

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -777,7 +777,7 @@ class InflationSDP:
     def certificate_as_dict(self,
                              clean: bool = True,
                              chop_tol: float = 1e-10,
-                             round_decimals: int = 3) -> sp.core.add.Add:
+                             round_decimals: int = 3) -> dict:
         """Give the polynomial certificate as a dictionary with monomials as
         keys and their coefficients as values. The certificate of
         incompatibility is read as ``cert < 0``. 

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -829,7 +829,18 @@ class InflationSDP:
 
     def probs_from_dict(self,
                         dict_with_monomial_keys: dict) -> sp.core.add.Add:
-        "Converts a monomial dictionary into a SymPy expression."
+        """Converts a monomial dictionary into a SymPy expression.
+
+        Parameters
+        ----------
+        dict_with_monomial_keys : Dict[sympy.Symbol, float]
+            Dictionary with monomials and associated coefficients.
+
+        Returns
+        -------
+        sympy.core.add.Add
+            The expression of the polynomial encoded in the dictionary.
+        """
         polynomial = sp.S.Zero
         for mon, coeff in self._sanitise_dict(dict_with_monomial_keys).items():
             polynomial += coeff * mon.symbol
@@ -878,6 +889,7 @@ class InflationSDP:
                          clean: bool = True,
                          round_decimals: int = 3) -> str:
         """Converts a monomial dictionary into a string.
+
         Parameters
         ----------
         clean : bool, optional
@@ -887,12 +899,19 @@ class InflationSDP:
         round_decimals : int, optional
             Coefficients that are not set to zero are formatted to the number
             of decimals specified. By default ``3``.
+        dict_with_monomial_keys : Dict[sympy.Symbol, float]
+            Dictionary with monomials and associated coefficients.
+
+        Returns
+        -------
+        str
+            The expression of the certificate in string form.
         """
         chop_tol = 10 ** (-round_decimals)
         as_dict = self._sanitise_dict(dict_with_monomial_keys)
         if clean:
             as_dict = clean_coefficients(as_dict, chop_tol, round_decimals)
-        # Watch out for when "1" is note the same as "constant_term
+        # Watch out for when "1" is note the same as "constant_term"
         constant_value = as_dict.pop(self.Constant_Term,
                                      as_dict.pop(self.One, 0.)
                                      )

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -277,6 +277,9 @@ class InflationSDP:
         self.monomial_from_name         = dict()
         self.Zero = self.Moment_2d(self.zero_operator, idx=0)
         self.One  = self.Moment_2d(self.identity_operator, idx=1)
+        self.Constant_Term = self.One.__copy__()
+        self.Constant_Term.name = self.constant_term_name
+        self.monomial_from_name[self.constant_term_name] = self.Constant_Term
 
         self.build_columns(column_specification)
         collect()
@@ -775,20 +778,19 @@ class InflationSDP:
     # PUBLIC ROUTINES RELATED TO THE PROCESSING OF CERTIFICATES               #
     ###########################################################################
     def certificate_as_dict(self,
-                             clean: bool = True,
-                             chop_tol: float = 1e-10,
-                             round_decimals: int = 3) -> dict:
-        """Give the polynomial certificate as a dictionary with monomials as
-        keys and their coefficients as values. The certificate of
-        incompatibility is read as ``cert < 0``. 
-        
+                            clean: bool = True,
+                            chop_tol: float = 1e-10,
+                            round_decimals: int = 3) -> dict:
+        """Give certificate as dictionary with monomials as keys and
+        their coefficients in the certificate as the values. The certificate
+        of incompatibility is ``cert < 0``.
+
         If the certificate is evaluated on a point giving a negative value, this
-        guarantess that the compatibility test for the same point is infeasible
+        guarantees that the compatibility test for the same point is infeasible
         provided the set of constraints of the program does not change. Warning:
         when using ``use_lpi_constraints=True`` the set of constraints depends
         on the specified distribution, thus the certificate is not guaranteed to
         apply.
-
 
         Parameters
         ----------
@@ -805,8 +807,8 @@ class InflationSDP:
 
         Returns
         -------
-        sympy.core.add.Add
-            The expression of the certificate in terms or probabilities and
+        dict
+            The expression of the certificate in terms of probabilities and
             marginals. The certificate of incompatibility is ``cert < 0``.
         """
         try:
@@ -818,20 +820,30 @@ class InflationSDP:
             warn("Beware that, because the problem contains linearized " +
                  "polynomial constraints, the certificate is not guaranteed " +
                  "to apply to other distributions.")
-        if clean and not np.allclose(list(dual.values()), 0.):
+        if np.allclose(list(dual.values()), 0.):
+            return dict()
+        if clean:
             dual = clean_coefficients(dual, chop_tol, round_decimals)
+        return {self.monomial_from_name[k]: v for k, v in dual.items()
+                if not self.monomial_from_name[k].is_zero}
 
-        return {self.monomial_from_name[k]: v for k, v in dual.items()}
-    
+    def probs_from_dict(self,
+                        dict_with_monomial_keys: dict) -> sp.core.add.Add:
+        "Converts a monomial dictionary into a SymPy expression."
+        polynomial = sp.S.Zero
+        for mon, coeff in self._sanitise_dict(dict_with_monomial_keys).items():
+            polynomial += coeff * mon.symbol
+        return polynomial
+
     def certificate_as_probs(self,
                              clean: bool = True,
                              chop_tol: float = 1e-10,
                              round_decimals: int = 3) -> sp.core.add.Add:
         """Give certificate as symbolic sum of probabilities. The certificate
         of incompatibility is ``cert < 0``.
-        
+
         If the certificate is evaluated on a point giving a negative value, this
-        guarantess that the compatibility test for the same point is infeasible
+        guarantees that the compatibility test for the same point is infeasible
         provided the set of constraints of the program does not change. Warning:
         when using ``use_lpi_constraints=True`` the set of constraints depends
         on the specified distribution, thus the certificate is not guaranteed to
@@ -853,38 +865,66 @@ class InflationSDP:
         Returns
         -------
         sympy.core.add.Add
-            The expression of the certificate in terms or probabilities and
+            The expression of the certificate in terms of probabilities and
             marginals. The certificate of incompatibility is ``cert < 0``.
         """
-        try:
-            dual = self.solution_object["dual_certificate"]
-        except AttributeError:
-            raise Exception("For extracting a certificate you need to solve " +
-                            "a problem. Call \"InflationSDP.solve()\" first.")
-        if len(self.semiknown_moments) > 0:
-            warn("Beware that, because the problem contains linearized " +
-                 "polynomial constraints, the certificate is not guaranteed " +
-                 "to apply to other distributions.")
-        if clean and not np.allclose(list(dual.values()), 0.):
-            dual = clean_coefficients(dual, chop_tol, round_decimals)
+        return self.probs_from_dict(self.certificate_as_dict(
+            clean=clean,
+            chop_tol=chop_tol,
+            round_decimals=round_decimals))
 
-        polynomial = sp.S.Zero
-        for mon_name, coeff in dual.items():
-            if clean and np.isclose(int(coeff), round(coeff, round_decimals)):
-                coeff = int(coeff)
-            polynomial += coeff * self.names_to_symbols[mon_name]
-        return polynomial
+    def string_from_dict(self,
+                         dict_with_monomial_keys: dict,
+                         clean: bool = True,
+                         round_decimals: int = 3) -> str:
+        """Converts a monomial dictionary into a string.
+        Parameters
+        ----------
+        clean : bool, optional
+            If ``True``, eliminate all coefficients that are smaller than
+            ``chop_tol``, normalise and round to the number of decimals
+            specified by ``round_decimals``. By default ``True``.
+        round_decimals : int, optional
+            Coefficients that are not set to zero are formatted to the number
+            of decimals specified. By default ``3``.
+        """
+        chop_tol = 10 ** (-round_decimals)
+        as_dict = self._sanitise_dict(dict_with_monomial_keys)
+        if clean:
+            as_dict = clean_coefficients(as_dict, chop_tol, round_decimals)
+        # Watch out for when "1" is note the same as "constant_term
+        constant_value = as_dict.pop(self.Constant_Term,
+                                     as_dict.pop(self.One, 0.)
+                                     )
+        if constant_value:
+            polynomial_as_str = "{0:.{prec}f}".format(constant_value,
+                                                      prec=round_decimals)
+        else:
+            polynomial_as_str = ""
+        for mon, coeff in as_dict.items():
+            if mon.is_zero or np.abs(coeff) <= chop_tol:
+                continue
+            else:
+                polynomial_as_str += "+" if coeff >= 0 else "-"
+                if np.isclose(abs(coeff), 1):
+                    polynomial_as_str += mon.name
+                else:
+                    polynomial_as_str += "{0:.{prec}f}*{1}".format(abs(coeff),
+                                                                   mon.name,
+                                                                   prec=round_decimals)
+        return polynomial_as_str[1:] if polynomial_as_str[
+                                            0] == "+" else polynomial_as_str
 
     def certificate_as_string(self,
                               clean: bool = True,
                               chop_tol: float = 1e-10,
                               round_decimals: int = 3) -> str:
-        """Give the certificate as a string with the notation of the operators
-        in the moment matrix. The expression is in the form such that
-        satisfaction implies incompatibility.
-        
+        """Give the certificate as a string of a sum of probabilities. The
+        expression is in the form such that its satisfaction implies
+        incompatibility.
+
         If the certificate is evaluated on a point giving a negative value, this
-        guarantess that the compatibility test for the same point is infeasible
+        guarantees that the compatibility test for the same point is infeasible
         provided the set of constraints of the program does not change. Warning:
         when using ``use_lpi_constraints=True`` the set of constraints depends
         on the specified distribution, thus the certificate is not guaranteed to
@@ -895,62 +935,58 @@ class InflationSDP:
         clean : bool, optional
             If ``True``, eliminate all coefficients that are smaller than
             ``chop_tol``, normalise and round to the number of decimals
-            specified by ``round_decimals``. By default ``True``.
+            specified by ``round_decimals``. By default, ``True``.
         chop_tol : float, optional
             Coefficients in the dual certificate smaller in absolute value are
-            set to zero. By default ``1e-10``.
+            set to zero. By default, ``1e-10``.
         round_decimals : int, optional
             Coefficients that are not set to zero are rounded to the number of
-            decimals specified. By default ``3``.
+            decimals specified. By default, ``3``.
 
         Returns
         -------
         str
-            The certificate in terms of symbols representing the monomials in
-            the moment matrix. The certificate of incompatibility is
-            ``cert < 0``.
+            The certificate in terms of probabilities and marginals. The
+            certificate of incompatibility is ``cert < 0``.
         """
-        try:
-            dual = self.solution_object["dual_certificate"]
-        except AttributeError:
-            raise Exception("For extracting a certificate you need to solve " +
-                            "a problem. Call \"InflationSDP.solve()\" first.")
-        if len(self.semiknown_moments) > 0:
-            if self.verbose > 0:
-                warn("Beware that, because the problem contains linearized " +
-                     "polynomial constraints, the certificate is not " +
-                     "guaranteed to apply to other distributions.")
+        return self.string_from_dict(
+            self.certificate_as_dict(
+                clean=clean,
+                chop_tol=chop_tol,
+                round_decimals=round_decimals),
+            round_decimals=round_decimals,
+            clean=False) + " < 0"
 
-        if clean and not np.allclose(list(dual.values()), 0.):
-            dual = clean_coefficients(dual, chop_tol, round_decimals)
+    def evaluate_polynomial(self, polynomial: dict, prob_array: np.ndarray):
+        """Evaluate the certificate of infeasibility in a target probability
+        distribution. If the evaluation is a negative value, the distribution is
+        not compatible with the causal structure. Warning: when using
+        ``use_lpi_constraints=True`` the set of constraints depends on the
+        specified distribution, thus the certificate is not guaranteed to apply.
 
-        rest_of_dual = dual.copy()
-        constant_value = rest_of_dual.pop(self.constant_term_name, 0)
-        constant_value += rest_of_dual.pop(self.One.name, 0)
-        if constant_value:
-            if clean:
-                cert = "{0:.{prec}f}".format(constant_value,
-                                             prec=round_decimals)
-            else:
-                cert = str(constant_value)
-        else:
-            cert = ""
-        for mon_name, coeff in rest_of_dual.items():
-            if mon_name != "0":
-                cert += "+" if coeff >= 0 else "-"
-                if np.isclose(abs(coeff), 1):
-                    cert += mon_name
-                else:
-                    if clean:
-                        cert += "{0:.{prec}f}*{1}".format(abs(coeff),
-                                                          mon_name,
-                                                          prec=round_decimals)
-                    else:
-                        cert += f"{abs(coeff)}*{mon_name}"
-        cert += " < 0"
-        return cert[1:] if cert[0] == "+" else cert
-    
-    def evaluate_certificate(self, prob_array):
+        Parameters
+        ----------
+        polynomial : dict
+            A dictionary of monomials with coefficients as values.
+        prob_array : numpy.ndarray
+            Multidimensional array encoding the distribution, which is
+            called as ``prob_array[a,b,c,...,x,y,z,...]`` where
+            :math:`a,b,c,\dots` are outputs and :math:`x,y,z,\dots` are
+            inputs. Note: even if the inputs have cardinality 1 they must
+            be specified, and the corresponding axis dimensions are 1.
+            The parties' outcomes and measurements must appear in the
+            same order as specified by the ``order`` parameter in the
+            ``InflationProblem`` used to instantiate ``InflationLP``.
+
+        Returns
+        -------
+        float
+            The evaluation of the certificate of infeasibility in prob_array.
+        """
+        return sum((atom.compute_marginal(prob_array) * val
+                    for atom, val in self._sanitise_dict(polynomial).items()))
+
+    def evaluate_certificate(self, prob_array: np.ndarray) -> float:
         """Evaluate the certificate of infeasibility in a target probability
         distribution. If the evaluation is a negative value, the distribution is
         not compatible with the causal structure. Warning: when using
@@ -965,9 +1001,9 @@ class InflationSDP:
             :math:`a,b,c,\dots` are outputs and :math:`x,y,z,\dots` are
             inputs. Note: even if the inputs have cardinality 1 they must
             be specified, and the corresponding axis dimensions are 1.
-            The parties' outcomes and measurements must be appear in the
+            The parties' outcomes and measurements must appear in the
             same order as specified by the ``order`` parameter in the
-            ``InflationProblem`` used to instantiate ``InflationSDP``.
+            ``InflationProblem`` used to instantiate ``InflationLP``.
 
         Returns
         -------
@@ -978,11 +1014,7 @@ class InflationSDP:
             warn("You have used LPI constraints to obtain the certificate. " +
                  "Be aware that, because of that, the certificate may not be " +
                  "valid for other distributions.")
-        cert = self.certificate_as_dict()
-        eval = 0
-        for atom, val in cert.items():
-            eval += atom.compute_marginal(prob_array) * val
-        return eval
+        return self.evaluate_polynomial(self.certificate_as_dict(), prob_array)
 
     ###########################################################################
     # OTHER ROUTINES EXPOSED TO THE USER                                      #

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -949,6 +949,40 @@ class InflationSDP:
                         cert += f"{abs(coeff)}*{mon_name}"
         cert += " < 0"
         return cert[1:] if cert[0] == "+" else cert
+    
+    def evaluate_certificate(self, prob_array):
+        """Evaluate the certificate of infeasibility in a target probability
+        distribution. If the evaluation is a negative value, the distribution is
+        not compatible with the causal structure. Warning: when using
+        ``use_lpi_constraints=True`` the set of constraints depends on the
+        specified distribution, thus the certificate is not guaranteed to apply.
+
+        Parameters
+        ----------
+        prob_array : numpy.ndarray
+            Multidimensional array encoding the distribution, which is
+            called as ``prob_array[a,b,c,...,x,y,z,...]`` where
+            :math:`a,b,c,\dots` are outputs and :math:`x,y,z,\dots` are
+            inputs. Note: even if the inputs have cardinality 1 they must
+            be specified, and the corresponding axis dimensions are 1.
+            The parties' outcomes and measurements must be appear in the
+            same order as specified by the ``order`` parameter in the
+            ``InflationProblem`` used to instantiate ``InflationSDP``.
+
+        Returns
+        -------
+        float
+            The evaluation of the certificate of infeasibility in prob_array.
+        """
+        if self.use_lpi_constraints:
+            warn("You have used LPI constraints to obtain the certificate. " +
+                 "Be aware that, because of that, the certificate may not be " +
+                 "valid for other distributions.")
+        cert = self.certificate_as_dict()
+        eval = 0
+        for atom, val in cert.items():
+            eval += atom.compute_marginal(prob_array) * val
+        return eval
 
     ###########################################################################
     # OTHER ROUTINES EXPOSED TO THE USER                                      #


### PR DESCRIPTION
This is something that @eliewolfe and I agreed that it would be very handy to have. Given a probability distribution `prob`, `Inflation(L/SD)P.evaluate_certificate(prob)` will evaluate the certificate of infeasibility (previously obtained) in `prob` and output the value.

I checked in some small examples that the function works correctly, the documentation is written, and the website has been changed accordingly.