### PR TITLE
Add Certificate class

### DIFF
--- a/docs/certificate.rst
+++ b/docs/certificate.rst
@@ -1,0 +1,4 @@
+Certificates of infeasibility
+====================
+.. autoclass:: inflation.certificate.Certificate
+    :members: as_dict, as_probs, as_string, evaluate, desymmetrize

--- a/docs/examples.ipynb
+++ b/docs/examples.ipynb
@@ -50,7 +50,7 @@
     {
      "data": {
       "text/plain": [
-       "'infeasible'"
+       "'dual_infeas_cer'"
       ]
      },
      "execution_count": 1,
@@ -123,7 +123,7 @@
     }
    ],
    "source": [
-    "cert = sdp.certificate_as_probs()\n",
+    "cert = sdp.certificate.as_probs()\n",
     "cert"
    ]
   },
@@ -152,10 +152,10 @@
    ],
    "source": [
     "# 2PR distribution\n",
-    "print(sdp.evaluate_certificate(P_2PR()))\n",
+    "print(sdp.certificate.evaluate(P_2PR()))\n",
     "\n",
     "# Uniform distribution\n",
-    "print(sdp.evaluate_certificate(np.ones_like(P_2PR()) / 8))"
+    "print(sdp.certificate.evaluate(np.ones_like(P_2PR()) / 8))"
    ]
   },
   {
@@ -706,7 +706,7 @@
     "                        sdp.known_moments,\n",
     "                        \"bisection\")\n",
     "print(\"Critical visibility:\", v,\n",
-    "      f\"\\nCertificate:\\n{sdp.certificate_as_string(chop_tol=1e-4)}\")"
+    "      f\"\\nCertificate:\\n{sdp.certificate.as_string(chop_tol=1e-4)}\")"
    ]
   },
   {
@@ -745,7 +745,7 @@
     "from sympy import Symbol\n",
     "prob_to_corr = {}\n",
     "\n",
-    "cert = sdp.certificate_as_probs(chop_tol=1e-4)\n",
+    "cert = sdp.certificate.as_probs(chop_tol=1e-4)\n",
     "for prob in cert.free_symbols:\n",
     "    inputs  = \"\".join([party.split(\"{\")[1][0] for party in str(prob).split(\",\")])\n",
     "    parties = \"\".join([party.split(\"_\")[0][-1] for party in str(prob).split(\",\")])\n",

--- a/docs/inflationlp.rst
+++ b/docs/inflationlp.rst
@@ -2,4 +2,4 @@ InflationLP Class
 ==================
 
 .. autoclass:: inflation.InflationLP
-   :members: _generate_lp, set_bounds, set_distribution, set_objective, set_values, update_values, solve, certificate_as_dict, certificate_as_probs, certificate_as_string, evaluate_certificate, reset, write_to_file
+   :members: _generate_lp, set_bounds, set_distribution, set_objective, set_values, update_values, solve, reset, write_to_file

--- a/docs/inflationsdp.rst
+++ b/docs/inflationsdp.rst
@@ -2,4 +2,4 @@ InflationSDP Class
 ==================
 
 .. autoclass:: inflation.InflationSDP
-   :members: generate_relaxation, set_bounds, set_distribution, set_objective, set_values, solve, build_columns, certificate_as_probs, certificate_as_string, evaluate_certificate, reset, write_to_file
+   :members: generate_relaxation, set_bounds, set_distribution, set_objective, set_values, solve, build_columns, reset, write_to_file

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -16,6 +16,8 @@ API Reference
 
    symmetry
 
+   certificate
+
    monomials
 
    build

--- a/inflation/certificate.py
+++ b/inflation/certificate.py
@@ -1,0 +1,38 @@
+"""
+This module encodes and handles certificates of infeasibility.
+
+@authors: Emanuel-Cristian Boghiu, Elie Wolfe, Alejandro Pozas-Kerstjens
+"""
+
+class Certificate(object):
+    """
+    Class for encoding relevant details concerning the causal compatibility.
+    """
+    def __init__(self,
+                 convexOptimizationProblem: Union["InflationLP", "InflationSDP"]
+                 ) -> None:
+        """
+        Parameters
+        ----------
+        convexOptimizationProblem : Union[InflationLP, InflationSDP]
+            The problem from which we take the certificate of infeasibility.
+        """
+
+    def as_dict(self,
+                clean: bool = True,
+                chop_tol: float = 1e-10,
+                round_decimals: int = 3) -> dict:
+
+    def as_string(self,
+                  clean: bool = True,
+                  chop_tol: float = 1e-10,
+                  round_decimals: int = 3) -> str:
+
+    def as_probs(self,
+                 clean: bool = True,
+                 chop_tol: float = 1e-10,
+                 round_decimals: int = 3) -> sp.core.add.Add:
+
+    def evaluate(self, prob_array: np.ndarray) -> float:
+
+    def desymmetrize(self) -> dict:

--- a/inflation/certificate.py
+++ b/inflation/certificate.py
@@ -183,5 +183,33 @@ class Certificate(object):
         return polynomial
 
     def evaluate(self, prob_array: np.ndarray) -> float:
+        """Evaluate the certificate of infeasibility in a target probability
+        distribution. If the evaluation is a negative value, the distribution is
+        not compatible with the causal structure. Warning: when using
+        ``use_lpi_constraints=True`` the set of constraints depends on the
+        specified distribution, thus the certificate is not guaranteed to apply.
+
+        Parameters
+        ----------
+        prob_array : numpy.ndarray
+            Multidimensional array encoding the distribution, which is
+            called as ``prob_array[a,b,c,...,x,y,z,...]`` where
+            :math:`a,b,c,\\dots` are outputs and :math:`x,y,z,\\dots` are
+            inputs. Note: even if the inputs have cardinality 1 they must
+            be specified, and the corresponding axis dimensions are 1.
+            The parties' outcomes and measurements must appear in the
+            same order as specified by the ``order`` parameter in the
+            ``InflationProblem`` used to instantiate ``InflationLP``.
+
+        Returns
+        -------
+        float
+            The evaluation of the certificate of infeasibility in prob_array.
+        """
+        if self.problem.use_lpi_constraints:
+            warn("You have used LPI constraints to obtain the certificate. " +
+                 "Be aware that, because of that, the certificate may not be " +
+                 "valid for other distributions.")
+        return self.problem.evaluate_polynomial(self.as_dict(), prob_array)
 
     def desymmetrize(self) -> dict:

--- a/inflation/certificate.py
+++ b/inflation/certificate.py
@@ -4,6 +4,14 @@ This module encodes and handles certificates of infeasibility.
 @authors: Emanuel-Cristian Boghiu, Elie Wolfe, Alejandro Pozas-Kerstjens
 """
 
+from warnings import warn
+from typing import Union
+
+import numpy as np
+import sympy as sp
+
+from .utils import clean_coefficients
+
 class Certificate(object):
     """
     Class for encoding relevant details concerning the causal compatibility.
@@ -17,21 +25,162 @@ class Certificate(object):
         convexOptimizationProblem : Union[InflationLP, InflationSDP]
             The problem from which we take the certificate of infeasibility.
         """
+        self.problem = convexOptimizationProblem
+        try:
+            self.certificate = self.problem.solution_object["dual_certificate"]
+        except AttributeError:
+            raise Exception("For extracting a certificate you need to solve " +
+                            "a problem. Call \"InflationSDP.solve()\" first.")
 
     def as_dict(self,
                 clean: bool = True,
                 chop_tol: float = 1e-10,
                 round_decimals: int = 3) -> dict:
+        """Give certificate as dictionary with monomials as keys and
+        their coefficients in the certificate as the values. The certificate
+        of incompatibility is ``cert < 0``.
+
+        If the certificate is evaluated on a point giving a negative value, this
+        guarantees that the compatibility test for the same point is infeasible
+        provided the set of constraints of the program does not change. Warning:
+        when using ``use_lpi_constraints=True`` the set of constraints depends
+        on the specified distribution, thus the certificate is not guaranteed to
+        apply.
+
+        Parameters
+        ----------
+        clean : bool, optional
+            If ``True``, eliminate all coefficients that are smaller than
+            ``chop_tol``, normalise and round to the number of decimals
+            specified by ``round_decimals``. By default ``True``.
+        chop_tol : float, optional
+            Coefficients in the dual certificate smaller in absolute value are
+            set to zero. By default ``1e-10``.
+        round_decimals : int, optional
+            Coefficients that are not set to zero are rounded to the number of
+            decimals specified. By default ``3``.
+
+        Returns
+        -------
+        dict
+            The expression of the certificate in terms of probabilities and
+            marginals. The certificate of incompatibility is ``cert < 0``.
+        """
+        if len(self.problem.semiknown_moments) > 0:
+            warn("Beware that, because the problem contains linearized " +
+                 "polynomial constraints, the certificate is not guaranteed " +
+                 "to apply to other distributions.")
+        if np.allclose(list(self.certificate.values()), 0.):
+            return {}
+        if clean:
+            cert = clean_coefficients(self.certificate, chop_tol, round_decimals)
+        else:
+            cert = self.certificate
+        return {self.problem.monomial_from_name[k]: v for k, v in cert.items()
+                if not self.problem.monomial_from_name[k].is_zero}
 
     def as_string(self,
                   clean: bool = True,
                   chop_tol: float = 1e-10,
                   round_decimals: int = 3) -> str:
+        """Give the certificate as a string of a sum of probabilities. The
+        expression is in the form such that its satisfaction implies
+        incompatibility.
+
+        If the certificate is evaluated on a point giving a negative value, this
+        guarantees that the compatibility test for the same point is infeasible
+        provided the set of constraints of the program does not change. Warning:
+        when using ``use_lpi_constraints=True`` the set of constraints depends
+        on the specified distribution, thus the certificate is not guaranteed to
+        apply.
+
+        Parameters
+        ----------
+        clean : bool, optional
+            If ``True``, eliminate all coefficients that are smaller than
+            ``chop_tol``, normalise and round to the number of decimals
+            specified by ``round_decimals``. By default, ``True``.
+        chop_tol : float, optional
+            Coefficients in the dual certificate smaller in absolute value are
+            set to zero. By default, ``1e-10``.
+        round_decimals : int, optional
+            Coefficients that are not set to zero are rounded to the number of
+            decimals specified. By default, ``3``.
+
+        Returns
+        -------
+        str
+            The certificate in terms of probabilities and marginals. The
+            certificate of incompatibility is ``cert < 0``.
+        """
+        cert_dict = self.as_dict(
+            clean=clean,
+            chop_tol=chop_tol,
+            round_decimals=round_decimals)
+        as_dict = self.problem._sanitise_dict(cert_dict)
+        # Watch out for when "1" is note the same as "constant_term"
+        constant_value = as_dict.pop(self.problem.Constant_Term,
+                                     as_dict.pop(self.problem.One, 0.)
+                                     )
+        if constant_value:
+            polynomial_as_str = str(constant_value)
+        else:
+            polynomial_as_str = ""
+        for mon, coeff in as_dict.items():
+            if mon.is_zero or np.isclose(np.abs(coeff), 0):
+                continue
+            else:
+                polynomial_as_str += "+" if coeff >= 0 else "-"
+                if np.isclose(abs(coeff), 1):
+                    polynomial_as_str += mon.name
+                else:
+                    polynomial_as_str += "{0}*{1}".format(abs(coeff), mon.name)
+
+        if polynomial_as_str[0] = "+":
+            polynomial_as_str = polynomial_as_str[1:]
+        return polynomial_as_str + " < 0"
 
     def as_probs(self,
                  clean: bool = True,
                  chop_tol: float = 1e-10,
                  round_decimals: int = 3) -> sp.core.add.Add:
+        """Give certificate as symbolic sum of probabilities. The certificate
+        of incompatibility is ``cert < 0``.
+
+        If the certificate is evaluated on a point giving a negative value, this
+        guarantees that the compatibility test for the same point is infeasible
+        provided the set of constraints of the program does not change. Warning:
+        when using ``use_lpi_constraints=True`` the set of constraints depends
+        on the specified distribution, thus the certificate is not guaranteed to
+        apply.
+
+        Parameters
+        ----------
+        clean : bool, optional
+            If ``True``, eliminate all coefficients that are smaller than
+            ``chop_tol``, normalise and round to the number of decimals
+            specified by ``round_decimals``. By default ``True``.
+        chop_tol : float, optional
+            Coefficients in the dual certificate smaller in absolute value are
+            set to zero. By default ``1e-10``.
+        round_decimals : int, optional
+            Coefficients that are not set to zero are rounded to the number of
+            decimals specified. By default ``3``.
+
+        Returns
+        -------
+        sympy.core.add.Add
+            The expression of the certificate in terms of probabilities and
+            marginals. The certificate of incompatibility is ``cert < 0``.
+        """
+        cert_dict = self.as_dict(
+            clean=clean,
+            chop_tol=chop_tol,
+            round_decimals=round_decimals)
+        polynomial = sp.S.Zero
+        for mon, coeff in self.problem._sanitise_dict(cert_dict).items():
+            polynomial += coeff * mon.symbol
+        return polynomial
 
     def evaluate(self, prob_array: np.ndarray) -> float:
 

--- a/inflation/certificate.py
+++ b/inflation/certificate.py
@@ -136,7 +136,7 @@ class Certificate(object):
                 else:
                     polynomial_as_str += "{0}*{1}".format(abs(coeff), mon.name)
 
-        if polynomial_as_str[0] = "+":
+        if polynomial_as_str[0] == "+":
             polynomial_as_str = polynomial_as_str[1:]
         return polynomial_as_str + " < 0"
 
@@ -227,9 +227,7 @@ class Certificate(object):
         desymmetrized = {}
         norm = len(self.problem.InflationProblem.symmetries)
         lexmon_names = self.problem.InflationProblem._lexrepr_to_copy_index_free_names
-        # TODO: Make that the lexorder in InflationLP and InflationSDP is the
-        # same, so we do not need this offset
-        offset = int(type(self.problem) is InflationSDP)
+        offset = int(self.problem.problem_type == "sdp")
         for symm in self.problem.InflationProblem.symmetries:
             for mon, coeff in self.certificate.items():
                 mon = self.problem.monomial_from_name[mon]

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -795,11 +795,10 @@ class InflationLP(object):
         float
             The evaluation of the certificate of infeasibility in prob_array.
         """
-        if self.use_lpi_constraints:
-            warn("You have used LPI constraints to obtain the certificate. " +
-                 "Be aware that, because of that, the certificate may not be " +
-                 "valid for other distributions.")
-        return self.evaluate_polynomial(self.certificate_as_dict(), prob_array)
+
+        warn("evaluate_certificate() will be removed from new versions of the "
+             + "library. Please use InflationLP.certificate.evaluate() instead")
+        return self.certificate.evaluate(prob_array)
 
     def desymmetrize_certificate(self) -> dict:
         """If the scenario contains symmetries other than the inflation

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -818,30 +818,10 @@ class InflationLP(object):
             probabilities and marginals. The certificate of incompatibility is
             ``cert < 0``.
         """
-        try:
-            dual = self.solution_object["dual_certificate"]
-        except AttributeError:
-            raise Exception("For extracting a certificate you need to solve " +
-                            "a problem. Call \"InflationSDP.solve()\" first.")
-
-        desymmetrized = {}
-        norm = len(self.InflationProblem.symmetries)
-        lexmon_names = self.InflationProblem._lexrepr_to_copy_index_free_names
-        for symm in self.InflationProblem.symmetries:
-            for mon, coeff in dual.items():
-                mon = self.monomial_from_name[mon]
-                if not mon.is_zero:
-                    desymm_mon = lexmon_names[symm[mon.as_lexmon]]
-                    desymm_mon = sorted(desymm_mon, key=lambda x: x[0])
-                    if not mon.is_one:
-                        desymm_name = "P[" + " ".join(desymm_mon) + "]"
-                    else:
-                        desymm_name = "1"
-                    if desymm_name not in desymmetrized:
-                        desymmetrized[desymm_name] = coeff / norm
-                    else:
-                        desymmetrized[desymm_name] += coeff / norm
-        return desymmetrized
+        warn("desymmetrize_certificate() will be removed from new versions of "
+             + "the library. Please use InflationLP.certificate.desymmetrize() "
+             + "instead")
+        return self.certificate.desymmetrize()
 
     ###########################################################################
     # OTHER ROUTINES EXPOSED TO THE USER                                      #

--- a/inflation/lp/InflationLP.py
+++ b/inflation/lp/InflationLP.py
@@ -19,6 +19,7 @@ from scipy.sparse import coo_array, vstack
 from tqdm import tqdm
 
 from .. import InflationProblem
+from ..certificate import Certificate
 from .lp_utils import solveLP
 from .monomial_classes import InternalAtomicMonomial, CompoundMoment
 from .numbafied import (nb_outer_bitwise_or,
@@ -615,6 +616,7 @@ class InflationLP(object):
         self.solution_object = solveLP(**args)
         self.success = self.solution_object["success"]
         self.status = self.solution_object["status"]
+        self.certificate = Certificate(self)
         if self.success:
             self.primal_objective = self.solution_object["primal_value"]
             self.objective_value  = self.solution_object["primal_value"]
@@ -661,40 +663,9 @@ class InflationLP(object):
             The expression of the certificate in terms of probabilities and
             marginals. The certificate of incompatibility is ``cert < 0``.
         """
-        try:
-            dual = self.solution_object["dual_certificate"]
-        except AttributeError:
-            raise Exception("For extracting a certificate you need to solve " +
-                            "a problem. Call \"InflationLP.solve()\" first.")
-        if len(self.semiknown_moments) > 0:
-            warn("Beware that, because the problem contains linearized " +
-                 "polynomial constraints, the certificate is not guaranteed " +
-                 "to apply to other distributions.")
-        if np.allclose(list(dual.values()), 0.):
-            return {}
-        if clean:
-            dual = clean_coefficients(dual, chop_tol, round_decimals)
-        return {self.monomial_from_name[k]: v for k, v in dual.items()
-                if not self.monomial_from_name[k].is_zero}
-
-    def probs_from_dict(self,
-                        dict_with_monomial_keys: dict) -> sp.core.add.Add:
-        """Converts a monomial dictionary into a SymPy expression.
-
-        Parameters
-        ----------
-        dict_with_monomial_keys : Dict[sympy.Symbol, float]
-            Dictionary with monomials and associated coefficients.
-
-        Returns
-        -------
-        sympy.core.add.Add
-            The expression of the polynomial encoded in the dictionary.
-        """
-        polynomial = sp.S.Zero
-        for mon, coeff in self._sanitise_dict(dict_with_monomial_keys).items():
-            polynomial += coeff * mon.symbol
-        return polynomial
+        warn("certificate_as_dict() will be removed from new versions of the "
+             + "library. Please use InflationLP.certificate.as_dict() instead")
+        return self.certificate.as_dict(clean, chop_tol, round_decimals)
 
     def certificate_as_probs(self,
                              clean: bool = True,
@@ -729,49 +700,9 @@ class InflationLP(object):
             The expression of the certificate in terms of probabilities and
             marginals. The certificate of incompatibility is ``cert < 0``.
         """
-
-        return self.probs_from_dict(self.certificate_as_dict(
-                clean=clean,
-                chop_tol=chop_tol,
-                round_decimals=round_decimals))
-
-    def string_from_dict(self,
-                         dict_with_monomial_keys) -> str:
-        """Converts a monomial dictionary into a string.
-
-        Parameters
-        ----------
-        dict_with_monomial_keys : Dict[sympy.Symbol, float]
-            Dictionary with monomials and associated coefficients.
-
-        Returns
-        -------
-        str
-            The expression of the certificate in string form.
-        """
-        as_dict = self._sanitise_dict(dict_with_monomial_keys)
-        # Watch out for when "1" is note the same as "constant_term"
-        constant_value = as_dict.pop(self.Constant_Term,
-                                     as_dict.pop(self.One, 0.)
-                                     )
-        if constant_value:
-            polynomial_as_str = str(constant_value)
-        else:
-            polynomial_as_str = ""
-        for mon, coeff in as_dict.items():
-            if mon.is_zero or np.isclose(np.abs(coeff), 0):
-                continue
-            else:
-                polynomial_as_str += "+" if coeff >= 0 else "-"
-                if np.isclose(abs(coeff), 1):
-                    polynomial_as_str += mon.name
-                else:
-                    polynomial_as_str += "{0}*{1}".format(abs(coeff), mon.name)
-        if not len(polynomial_as_str):  # Failsafe for empty dictionary.
-            polynomial_as_str = "0"
-        elif polynomial_as_str[0] == "+":
-            polynomial_as_str = polynomial_as_str[1:]
-        return polynomial_as_str
+        warn("certificate_as_probs() will be removed from new versions of the "
+             + "library. Please use InflationLP.certificate.as_probs() instead")
+        return self.certificate.as_probs(clean, chop_tol, round_decimals)
 
     def certificate_as_string(self,
                               clean: bool = True,
@@ -807,11 +738,9 @@ class InflationLP(object):
             The certificate in terms of probabilities and marginals. The
             certificate of incompatibility is ``cert < 0``.
         """
-        return self.string_from_dict(
-            self.certificate_as_dict(
-                clean=clean,
-                chop_tol=chop_tol,
-                round_decimals=round_decimals)) + " < 0"
+        warn("certificate_as_string() will be removed from new versions of the "
+             + "library. Please use InflationLP.certificate.as_string() instead")
+        return self.certificate.as_string(clean, chop_tol, round_decimals)
 
     def evaluate_polynomial(self, polynomial: dict, prob_array: np.ndarray):
         """Evaluate the certificate of infeasibility in a target probability
@@ -841,7 +770,6 @@ class InflationLP(object):
         """
         return sum((atom.compute_marginal(prob_array) * val
                     for atom, val in self._sanitise_dict(polynomial).items()))
-
 
     def evaluate_certificate(self, prob_array: np.ndarray) -> float:
         """Evaluate the certificate of infeasibility in a target probability

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -1069,30 +1069,10 @@ class InflationSDP:
             probabilities and marginals. The certificate of incompatibility is
             ``cert < 0``.
         """
-        try:
-            dual = self.solution_object["dual_certificate"]
-        except AttributeError:
-            raise Exception("For extracting a certificate you need to solve " +
-                            "a problem. Call \"InflationSDP.solve()\" first.")
-
-        desymmetrized = {}
-        norm = len(self.InflationProblem.symmetries)
-        lexmon_names = self.InflationProblem._lexrepr_to_copy_index_free_names
-        for symm in self.InflationProblem.symmetries:
-            for mon, coeff in dual.items():
-                mon = self.monomial_from_name[mon]
-                if not mon.is_zero:
-                    desymm_mon = lexmon_names[symm[mon.as_lexmon-1]]
-                    desymm_mon = sorted(desymm_mon, key=lambda x: x[0])
-                    if not mon.is_one:
-                        desymm_name = "P[" + " ".join(desymm_mon) + "]"
-                    else:
-                        desymm_name = "1"
-                    if desymm_name not in desymmetrized:
-                        desymmetrized[desymm_name] = coeff / norm
-                    else:
-                        desymmetrized[desymm_name] += coeff / norm
-        return desymmetrized
+        warn("desymmetrize_certificate() will be removed from new versions of "
+             + "the library. Please use InflationLP.certificate.desymmetrize() "
+             + "instead")
+        return self.certificate.desymmetrize()
 
     ###########################################################################
     # OTHER ROUTINES EXPOSED TO THE USER                                      #

--- a/inflation/sdp/InflationSDP.py
+++ b/inflation/sdp/InflationSDP.py
@@ -1053,11 +1053,9 @@ class InflationSDP:
         float
             The evaluation of the certificate of infeasibility in prob_array.
         """
-        if self.use_lpi_constraints:
-            warn("You have used LPI constraints to obtain the certificate. " +
-                 "Be aware that, because of that, the certificate may not be " +
-                 "valid for other distributions.")
-        return self.evaluate_polynomial(self.certificate_as_dict(), prob_array)
+        warn("evaluate_certificate() will be removed from new versions of the "
+             + "library. Please use InflationLP.certificate.evaluate() instead")
+        return self.certificate.evaluate(prob_array)
 
     def desymmetrize_certificate(self) -> dict:
         """If the scenario contains symmetries other than the inflation

--- a/test/test_symmetry.py
+++ b/test/test_symmetry.py
@@ -97,7 +97,7 @@ class TestSymmetry(unittest.TestCase):
         lp = InflationLP(self.bellScenario, verbose=0)
         lp.set_distribution(self.PR_box)
         lp.solve()
-        certificate = lp.desymmetrize_certificate()
+        certificate = lp.certificate.desymmetrize()
         truth = {
             'P[A_0=0]': 0.125, 'P[A_0=1]': 0.125, 'P[A_1=0]': 0.125, 'P[A_1=1]': 0.125,
             'P[B_0=0]': 0.125, 'P[B_0=1]': 0.125, 'P[B_1=0]': 0.125, 'P[B_1=1]': 0.125,


### PR DESCRIPTION
This PR creates a unified `Certificate` class to handle certificates of infeasibility. It reduces code duplication since we move from two copies of the code (one in InflationLP and another one in InflationSDP) to just a single one. The PR already contains the necessary documentation. For the old use of the functions, I added a deprecation notice, so they can still be used until we bump to v3.0.0.